### PR TITLE
feat(esco-content-menu): optionally allow categories to appear in footer

### DIFF
--- a/@uportal/esco-content-menu/src/components/ContentGrid.vue
+++ b/@uportal/esco-content-menu/src/components/ContentGrid.vue
@@ -297,9 +297,7 @@ $searchSize: 32px;
     line-height: 1.5;
     color: #495057;
     vertical-align: middle;
-    background: #fff
-      url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 4 5'%3E%3Cpath fill='%23343a40' d='M2 0L0 2h4zm0 5L0 3h4z'/%3E%3C/svg%3E")
-      no-repeat right 0.75rem center;
+    background-color: #fff;
     background-size: auto auto;
     background-size: 8px 10px;
     border: 1px solid #ced4da;


### PR DESCRIPTION
```html
<content-grid
      background-color="grey"
      portlet-card-size="medium"
      show-footer-categories>
      <div slot="header-right"></div>
</content-grid>
```

![footer-categories](https://user-images.githubusercontent.com/3107513/49386857-b6360900-f6dd-11e8-99d2-934d7f9881c0.gif)


//cc @mindblender