### PR TITLE
docs: bump core-js-bundle to 3.0.0-beta.8 like uPortal#1499

### DIFF
--- a/docs/en/components/content-carousel/demo.html
+++ b/docs/en/components/content-carousel/demo.html
@@ -36,7 +36,7 @@
     </content-carousel>
 
     <script src="https://unpkg.com/vue"></script>
-    <script src="https://unpkg.com/core-js-bundle@3.0.0-beta.3"></script>
+    <script src="https://unpkg.com/core-js-bundle@3.0.0-beta.8"></script>
     <script src="https://unpkg.com/regenerator-runtime/runtime.js"></script>
     <script src="https://unpkg.com/whatwg-fetch"></script>
     <script src="https://unpkg.com/@webcomponents/webcomponentsjs"></script>

--- a/docs/en/components/dashboard-carousel/demo.html
+++ b/docs/en/components/dashboard-carousel/demo.html
@@ -9,7 +9,7 @@
     </dashboard-carousel>
 
     <script src="https://unpkg.com/vue"></script>
-    <script src="https://unpkg.com/core-js-bundle@3.0.0-beta.3"></script>
+    <script src="https://unpkg.com/core-js-bundle@3.0.0-beta.8"></script>
     <script src="https://unpkg.com/regenerator-runtime/runtime.js"></script>
     <script src="https://unpkg.com/whatwg-fetch"></script>
     <script src="https://unpkg.com/@webcomponents/webcomponentsjs"></script>

--- a/docs/en/components/esco-content-menu/demo.html
+++ b/docs/en/components/esco-content-menu/demo.html
@@ -75,7 +75,7 @@
     </section>
     <footer></footer>
     <script src="https://unpkg.com/vue"></script>
-    <script src="https://unpkg.com/core-js-bundle@3.0.0-beta.3"></script>
+    <script src="https://unpkg.com/core-js-bundle@3.0.0-beta.8"></script>
     <script src="https://unpkg.com/regenerator-runtime/runtime.js"></script>
     <script src="https://unpkg.com/whatwg-fetch"></script>
     <script src="https://unpkg.com/@webcomponents/webcomponentsjs"></script>

--- a/docs/en/components/waffle-menu/demo.html
+++ b/docs/en/components/waffle-menu/demo.html
@@ -70,7 +70,7 @@
       </nav>
     </header>
 
-    <script src="https://unpkg.com/core-js-bundle@3.0.0-beta.3"></script>
+    <script src="https://unpkg.com/core-js-bundle@3.0.0-beta.8"></script>
     <script src="https://unpkg.com/regenerator-runtime/runtime.js"></script>
     <script src="https://unpkg.com/whatwg-fetch"></script>
     <script src="https://unpkg.com/@webcomponents/webcomponentsjs"></script>


### PR DESCRIPTION
to have demo on same version than https://github.com/Jasig/uPortal/pull/1499