### PR TITLE
docs: replace symlink to provide docs on npm site

### DIFF
--- a/@uportal/esco-content-menu/README.md
+++ b/@uportal/esco-content-menu/README.md
@@ -1,1 +1,438 @@
-../../docs/en/components/esco-content-menu/README.md
+# ESCO Content Menu
+
+[![NPM Version](https://img.shields.io/npm/v/@uportal/esco-content-menu.svg)](https://www.npmjs.com/package/@uportal/esco-content-menu)
+[![Maven Central](https://maven-badges.herokuapp.com/maven-central/org.webjars.npm/uportal__esco-content-menu/badge.svg)](https://maven-badges.herokuapp.com/maven-central/org.webjars.npm/uportal__esco-content-menu)
+[![Build Status](https://travis-ci.org/uPortal-contrib/uPortal-web-components.svg?branch=master)](https://travis-ci.org/uPortal-contrib/uPortal-web-components)
+
+## Demo
+
+<https://uportal-contrib.github.io/uPortal-web-components/en/components/esco-content-menu/demo>
+
+## Installation
+
+```bash
+# install with npm
+npm install @uportal/esco-content-menu
+
+# install with yarn
+yarn add @uportal/esco-content-menu
+```
+
+_install with maven_
+
+```xml
+<dependency>
+    <groupId>org.webjars.npm</groupId>
+    <artifactId>uportal__esco-content-menu</artifactId>
+    <version>{version number goes here}</version>
+</dependency>
+```
+
+_install with gradle_
+
+```gradle
+compile 'org.webjars.npm:uportal__esco-content-menu:{version number goes here}'
+```
+
+## Usage as Web Component
+
+### The hamburger menu
+
+This is the main component that show a hamburger menu and that open an entire page with `content-menu` component.
+
+#### Html
+
+```html
+<script src="/resource-server/webjars/vue/dist/vue.min.js"></script>
+<script
+  src="/resource-server/webjars/uportal__esco-content-menu/dist/esco.min.js"
+  defer
+></script>
+
+<esco-hamburger-menu
+  default-org-logo="..."
+  api-url-org-info="..."
+  portlet-api-url="..."
+  layout-api-url="..."
+  organization-api-url="..."
+  user-info-api-url="..."
+  context-api-url="/uPortal"
+  sign-out-url="/uPortal/Logout"
+  default-org-logo="https://www.toureiffel.paris/sites/default/files/styles/1440x810/public/2017-10/monument-landing-header-bg_0.jpg?itok=_dSLLBlZ"
+  user-info-portlet-url="/uPortal/user-details"
+  favorites-portlet-card-size="small"
+  grid-portlet-card-size="auto"
+  hide-action-mode="never"
+>
+</esco-hamburger-menu>
+```
+
+For some integration you could need a bit more, like into uPortal you will need to add a parent div and to apply on his closest parent `section` a style `float: left`.
+
+#### Properties
+
+- `context-api-url`: type: `String`, default: `/uPortal`, usefull to provide a different uPortal context on which to do request
+- `favorite-api-url`: type: `String`, default: `/uPortal/api/layout`, the uri/url of the favorites api
+- `layout-api-url`: type: `String`, default: `/uPortal/api/v4-3/dlm/layout.json`, the uri/url of the layout api to request the favorite list in the oser defined order (only needed to get favorite's order defined by the user)
+- `portlet-api-url`: type: `String`, default: `/uPortal/api/v4-3/dlm/portletRegistry.json`, the uri/url of the portletRegistry api to obtains user authorized portlet list
+- `userInfo-api-url`: type: `String`, default: `/uPortal/api/v5-1/userinfo`, url/uri on which the api request is done to obtain user information and the jwt token
+- `organization-api-url`: type: `String`, optional, an uri/url of an api to retrieve organization informations, any json format is accepted, but configure `user-org-id-attribute-name`, `user-all-orgs-id-attribute-name`, `org-logo-url-attribute-name` to work with.
+- `sign-out-url`: type: `String`, default: `/uPortal/Logout`, an uri/url to call when user logout (for a logout button),
+- `default-org-logo`: type: `String`, required: true, an url/uri to provide an institutional picture when none is found from an optional api (not provided into uPortal),
+- `user-info-portlet-url`: type: `String`, default: `''`, an url/uri to the user information application,
+- `switch-org-portlet-url`: type: `String`, default: `''`, an optional url/url of a rest api to obtain institutional organization information,
+- `favorites-portlet-card-size`: type: possible value `auto|large|medium|small|smaller`, default: `auto`, define the size of portlet-cards component into `favorite-content` component part,
+- `grid-portlet-card-size`: type: possible value `auto|large|medium|small|smaller`, default: `auto`, define the size of `portlet-cards` component into `grid-content` component part,
+- `hide-action-mode: type`: possible value `auto|always|never`, default: `auto`, define if we should show the actions, `auto` don't show on `small` breakpoint,
+- `user-org-id-attribute-name`: type: `String`, default: `'ESCOSIRENCourant[0]'`, the attribute object path to obtain the id of the organization to retrieve from the organization's api
+- `user-all-orgs-id-attribute-name`: type: `String`, default: `'ESCOSIREN`, the attribute object path to obtain all ids of the organizations linked to the user and to retrieve from the organization's api
+- `org-logo-url-attribute-name`: type: `String`, default: `'otherAttributes.ESCOStructureLogo[0]'`, the attribute object path to obtain the organization Picture from organization details obtained from the organization's api
+- `debug`: type: `Boolean`, default: `false`, for the demo/debug mode to be able to run in a standalone way (disable api call).
+
+#### Slots
+
+The HTML content of the component can also be modified using [slots](https://vuejs.org/v2/guide/components-slots.html).
+
+##### Menu Icon
+
+The `menu-icon` slot permit to apply a custom icon replacing the default Hamburger one. As example:
+
+```html
+<esco-hamburger-menu
+  default-org-logo="..."
+  api-url-org-info="..."
+  portlet-api-url="..."
+  layout-api-url="..."
+  organization-api-url="..."
+  user-info-api-url="..."
+  favorites-portlet-card-size="small"
+  grid-portlet-card-size="auto"
+  hide-action-mode="never"
+>
+  <div
+    slot="menu-icon"
+    style="background-image:url('https://mdbootstrap.com/img/svg/hamburger3.svg?color=FFF');height:20px;width:20px;"
+  ></div>
+</esco-hamburger-menu>
+```
+
+##### Menu Content
+
+The `menu-content` slot permit to apply an other content than the esco-content-menu sub-component.
+
+```html
+<esco-hamburger-menu
+  favorites-portlet-card-size="small"
+  grid-portlet-card-size="auto"
+  hide-action-mode="never"
+>
+  <div slot="menu-content">whatever...</div>
+</esco-hamburger-menu>
+```
+
+### The content menu
+
+This component is a main one as it will load into one page all main elements (the user + organization information, the favorites and the list of services )
+
+#### Html
+
+```html
+<script src="/resource-server/webjars/vue/dist/vue.min.js"></script>
+<script
+  src="/resource-server/webjars/uportal__esco-content-menu/dist/esco.min.js"
+  defer
+></script>
+
+<esco-content-menu
+  sign-out-url="/uPortal/Logout"
+  default-org-logo="https://www.toureiffel.paris/sites/default/files/styles/1440x810/public/2017-10/monument-landing-header-bg_0.jpg?itok=_dSLLBlZ"
+  user-info-portlet-url="/uPortal/user-details"
+  favorites-portlet-card-size="small"
+  grid-portlet-card-size="auto"
+  hide-action-mode="never"
+>
+</esco-content-menu>
+```
+
+#### Properties
+
+This use the same properties from the `hamburger-menu` (see on `hamburger-menu` details):
+
+- `context-api-url`
+- `favorite-api-url`
+- `layout-api-url`
+- `organization-api-url`
+- `user-info-api-url`
+- `portlet-api-url`
+- `sign-out-url`
+- `default-org-logo`
+- `user-info-portlet-url`
+- `switch-org-portlet-url`
+- `favorites-portlet-card-size`
+- `grid-portlet-card-size`
+- `hide-action-mode`
+- `user-org-id-attribute-name`
+- `user-all-orgs-id-attribute-name`
+- `org-logo-url-attribute-name`
+- `debug`
+
+and with additional properties to work with the `hamburger-menu`:
+
+- `call-on-close`: type: `Function`, default: `{}`, provide to this property a callback function to call after clicking on the header-button close of the `header-buttons` component.
+- `is-hidden`: type: `Boolean`, default: `false`, used by the `hamburger-menu` to indicate the state of the page.
+- `id`: type: `String`, default: `null`, provide an id to be able to select the dome element, as example if you want to manage manualy an `hamburger-menu`
+
+### The content grid
+
+This component provide a flexbox way to show a list of `portlet-card`, depending on uPortal rest-api.
+
+#### Html
+
+```html
+<script src="/resource-server/webjars/vue/dist/vue.min.js"></script>
+<script
+  src="/resource-server/webjars/uportal__esco-content-menu/dist/esco.min.js"
+  defer
+></script>
+
+<esco-content-grid
+  portlet-card-size="gridPortletCardSize"
+  hide-action="hideAction"
+>
+</esco-content-grid>
+```
+
+#### Properties
+
+Standalone properties:
+
+- `background-color`: type: `String`, default: `rgba(0, 0, 0, 0)`, to apply a different background-color
+- `call-after-action`: type: `Function`, default: `undefined`, a callback function to call into `portlet-card` embeding `action-favorite` after adding portlet to favorites,
+- `context-api-url`: type: `String`, default: `/uPortal`, usefull to provide a different uPortal context on which to do request,
+- `favorite-api-url`: type: `String`, default: `/uPortal/api/layout`, the uri/url of the favorites api
+- `layout-api-url`: type: `String`, default: `/uPortal/api/v4-3/dlm/layout.json`, the uri/url of the layout api to request the favorite list in the other defined order (only needed to get favorite's order defined by the user)
+- `portlet-api-url`: type: `String`, default: `/uPortal/api/v4-3/dlm/portletRegistry.json`, the uri/url of the portletRegistry api to obtains user authorized portlet list
+- `userInfo-api-url`: type: `String`, default: `/uPortal/api/v5-1/userinfo`, url/uri on which the api request is done to obtain user information and the jwt token
+- `portlet-card-size`: type: possible value `auto|large|medium|small|smaller`, default: `auto`, define the size of `portlet-cards` component.
+- `hide-action: type`: `Boolean`, default: `false`, define to hide or not the `action-favorite` button defined into `portlet-card`
+- `show-footer-categories`: `Boolean`, default: `false`, define to display category dropdown filter near bottom of grid
+- `hide-title`: `Boolean`, default: `false`, define to remove the title area from the grid, useful when a basic grid is desired
+- `debug`: type: `Boolean`, default: `false`, for the demo/debug mode to be able to run in a standalone way (disable api call)
+
+and additional properties to work with the parent component `content-menu`:
+
+- `parent-screen-size`: type: possible value `large|medium|small|smaller`, default: `medium`, permit to indicate the breakpoint view of the parent.
+- `portlets`: type: `Array`, default: `undefined`, used if the list of portlets is loaded and provided from a parent component,
+- `favorites`: type: `Array`, default: `undefined`, used if the list of favorites portlets loaded and provided from a parent component,
+
+#### Slots
+
+The HTML content of the component can also be modified using [slots](https://vuejs.org/v2/guide/components-slots.html).
+
+##### Header Left
+
+The `header-left` slot permit to apply a custom title replacing the default "All services" one. As example:
+
+```html
+<content-grid
+  background-color="grey"
+  portlet-card-size="medium"
+  portlet-api-url="/uPortal/api/v4-3/dlm/portletRegistry.json?category=administration"
+  layout-api-url="..."
+>
+  <h1 slot="header-left">Administration</h1>
+</content-grid>
+```
+
+##### Header Right
+
+The `header-right` slot permit to apply a custom title replacing the default filter on right. As example:
+
+```html
+<content-grid
+  background-color="grey"
+  portlet-card-size="medium"
+  portlet-api-url="/uPortal/api/v4-3/dlm/portletRegistry.json?category=administration"
+  layout-api-url="..."
+>
+  <div slot="header-rigth"></div>
+</content-grid>
+```
+
+##### Footer
+
+The `footer` slot permit to apply a custom title replacing the default filter on footer. As example:
+
+```html
+<content-grid
+  background-color="grey"
+  portlet-card-size="medium"
+  portlet-api-url="/uPortal/api/v4-3/dlm/portletRegistry.json"
+  layout-api-url="..."
+>
+  <div slot="footer"></div>
+</content-grid>
+```
+
+### The action favorite
+
+The component `action-favorite` is really simple, it show a start button that permit to add or remove from favorites a portlet.
+
+### Html
+
+```html
+<script src="/resource-server/webjars/vue/dist/vue.min.js"></script>
+<script
+  src="/resource-server/webjars/uportal__esco-content-menu/dist/esco.min.js"
+  defer
+></script>
+
+<esco-action-favorite portlet-card-size="small" hide-action="false">
+</esco-action-favorite>
+```
+
+#### Properties
+
+- `call-on-toggle-fav`: type: `Function`, default: `{}`, a callback function called after the click event on the button,
+- `chan-id`: type: `String`, required: `true`, the portlet id to add or remove from user favorites,
+- `favorite-api-url`: type: `String`, default: `/uPortal/api/layout`, the uri/url of the favorites api,
+- `user-info-api-url`: type: `String`, default: `/uPortal/api/v5-1/userinfo`, url/uri on which the api request is done to obtain user information and the jwt token,
+- `fname`: type: `String`, required: `true`, the portlet fname that permit to identify the portlet into favorite's list, usefull for the callback function and apply a css class,
+- `is-favorite`: type: `Boolean`, default: `false`, provide the favorite state,
+- `back-ground-is-dark`: type: `Boolean`, default: `false`, permit to apply a style depending on background color, as the component is used as embeded,
+- `debug`: type: `Boolean`, default: `false`, for the demo/debug mode to be able to run in a standalone way (disable favorites api call)
+
+### The content favorites
+
+The component is functional only into the `content-menu`, it needs that a portlet list and favorite list is passed
+
+Somme work would be needed to move on the `content-carousel`.
+
+### The content user
+
+This component permit to show user information with his organization information.
+Few work would be need to be able to use it as a standalone component: like having a fetch service like for portlets or favorite. But some parts are institutional developpments to be able to obtain organization informations, so we are waiting new usecase before to do something.
+
+#### Html
+
+Need some work for a standalone use.
+
+#### Properties
+
+- `context-api-url`: type: `String`, default: `/uPortal`, usefull to provide a different uPortal context on which to do request
+- `org-info`: type: `Object`, default: `{}`, the current user organization detail object,
+- `other-orgs`: type: `Array`, default: `[]`, all other organizations details object when the user have several,
+- `user-info`: type: `Object`, required: `true`, the user information object,
+- `switch-org-portlet-url`: type: `String`, default: `'''`, an url/uri where the user can switch of organization when having several (tenant use part),
+- `default-org-logo`: type: `String`, required: `true`, an url/uri to provide an institutional picture when none is found from an optional api (not provided into uPortal),
+- `user-info-portlet-url`: type: `String`, default: `''`, an url/uri to the user information application,
+- `org-logo-url-attribute-name`: type: `String`, default: `'otherAttributes.ESCOStructureLogo[0]'`, the attribute object path to obtain the organization Picture from organization details obtained from the organization's api.
+
+and additional properties to work with the parent component `content-menu`:
+
+- `parent-screen-size`: type: possible value `large|medium|small|smaller`, default: `medium`, permit to indicate the breakpoint view of the parent.
+
+### The portlet card
+
+This component render informations about a portlet as a card.
+
+#### Html
+
+```html
+<script src="/resource-server/webjars/vue/dist/vue.min.js"></script>
+<script
+  src="/resource-server/webjars/uportal__esco-content-menu/dist/esco.min.js"
+  defer
+></script>
+
+<esco-portlet-card portlet-desc="portlet" size="small" hide-action="true">
+</esco-portlet-card>
+```
+
+#### Properties
+
+- `portlet-desc`: type: `Object`, required: `true`, the portlet description object
+- `size`: type: possible value `large|medium|small|smaller`, default: `medium`, the fixed size of card to apply
+- `hide-action: type`: `Boolean`, default: `false`, define to hide or not the `action-favorite` button
+- `back-ground-is-dark`: type: `Boolean`, default: `false`, permit to apply a style depending on background color, as the component is used as embeded,
+- `is-favorite`: type: `Boolean`, default: `false`, provide the favorite state (passed to the `action-favorite` component),
+- `call-after-action`: type: `Function`, default: `{}`, callback function to call after click on `action-favorite` button (passed to the `action-favorite` component),
+- `icon-background-color`: type: `String`, default: `Transparent`, could be used to apply a background-color behind a portlet icon - usecase if there isn't background on icon.
+- `favorite-api-url`: type: `String`, default: `/uPortal/api/layout`, the uri/url of the favorites api (passed to the `action-favorite` component),
+- `user-info-api-url`: type: `String`, default: `/uPortal/api/v5-1/userinfo`, url/uri on which the api request is done to obtain user information and the jwt token, (passed to the `action-favorite` component),
+- `debug`: type: `Boolean`, default: `false`, for the demo/debug mode to be able to run in a standalone way (disable api call).
+
+### The content grid category filter
+
+This component is an external version of the filter built into Content Grid that allows for arbitrary placement on the page.
+
+#### Html
+
+```html
+<script src="/resource-server/webjars/vue/dist/vue.min.js"></script>
+<script
+  src="/resource-server/webjars/uportal__esco-content-menu/dist/esco.min.js"
+  defer
+></script>
+
+<esco-content-grid
+  portlet-card-size="gridPortletCardSize"
+  hide-action="hideAction"
+>
+</esco-content-grid>
+
+<esco-content-grid-filter></esco-content-grid-filter>
+```
+
+#### Properties
+
+- none
+
+### The ellipsis
+
+This component permit to apply an auto-fit/trunc or a line-clamping to a text when the div size should be limited. It avoids to apply an overflow: hidden and permit to manage an ellipsis on several line.
+
+#### Html
+
+```html
+<script src="/resource-server/webjars/vue/dist/vue.min.js"></script>
+<script src="/resource-server/webjars/uportal__esco-content-menu/dist/esco.min.js" defer></script>
+
+<esco-ellipsis
+  message="text">
+</esco-elipsis>
+```
+
+#### Properties
+
+- `message`: type: `String`, default: `''`, the text to "ellipsise",
+- `line-clamp`: type: `Number`, default: `0`, when we want a number of line, else will apply an auto-fit on te available size (the parent should have a defined height),
+- `line-height`: type: `String`, default: `'22px'`, the line heigth of the text is required for the auto-fit,
+- `end-char`: type: `String`, default: `'...'`, a text to apply when a trunc appear,
+- `end-html`: type: `String`, default: `''`, a text to apply at end of the html.
+
+### The header buttons
+
+This component render a header part with some main buttons, like closing the page menu or to sign out.
+
+#### Html
+
+```html
+<script src="/resource-server/webjars/vue/dist/vue.min.js"></script>
+<script
+  src="/resource-server/webjars/uportal__esco-content-menu/dist/esco.min.js"
+  defer
+></script>
+
+<esco-header-button call-on-close="function"> </esco-header-button>
+```
+
+#### Properties
+
+- `call-on-close`: type: `Function`, default: `{}`, callback function on click on the close button,
+- `sign-out-url`: type: `String`, default: `/uPortal/Logout`, an uri/url to call when user logout (for a logout button),
+
+## FAQ
+
+- Q: What does "ESCO" mean?
+- A: "ESCO" is an abbreviation of "e-scolaire", French for Online School.

--- a/@uportal/esco-content-menu/public/adminPortlets.json
+++ b/@uportal/esco-content-menu/public/adminPortlets.json
@@ -1,1 +1,199 @@
-../../../docs/en/components/esco-content-menu/adminPortlets.json
+{
+  "registry": {
+    "categories": [
+      {
+        "name": "uPortal",
+        "description": "Services natifs uPortal",
+        "id": "local.22",
+        "portlets": [
+          {
+            "fname": "portal-activity",
+            "keywords": [],
+            "description": "Afficher l'activité dans le portail",
+            "title": "Activité dans le portail",
+            "averageRating": 0,
+            "name": "Activité dans le portail",
+            "ratingsCount": 0,
+            "typeId": 7,
+            "id": 22,
+            "state": "PUBLISHED",
+            "favorite": false,
+            "parameters": {
+              "iconUrl": {
+                "name": "iconUrl",
+                "description": "",
+                "value": "https://ent.recia.fr/ResourceServingWebapp/rs/tango/0.8.90/32x32/categories/preferences-system.png"
+              }
+            }
+          },
+          {
+            "fname": "portlet-admin",
+            "keywords": [],
+            "description": "Portlets d'administration des portlets",
+            "title": "Administration des portlets",
+            "averageRating": 0,
+            "name": "Administration des portlets",
+            "ratingsCount": 0,
+            "typeId": 7,
+            "id": 26,
+            "state": "PUBLISHED",
+            "favorite": false,
+            "parameters": {
+              "iconUrl": {
+                "name": "iconUrl",
+                "description": "",
+                "value": "https://ent.recia.fr/ResourceServingWebapp/rs/tango/0.8.90/32x32/categories/preferences-system.png"
+              }
+            }
+          },
+          {
+            "fname": "portal-administration",
+            "keywords": [],
+            "description": "Menu des portlets d'administration du portail",
+            "title": "Administration du portail",
+            "averageRating": 0,
+            "name": "Administration du portail",
+            "ratingsCount": 0,
+            "typeId": 7,
+            "id": 23,
+            "state": "PUBLISHED",
+            "favorite": true,
+            "parameters": {
+              "iconUrl": {
+                "name": "iconUrl",
+                "description": "",
+                "value": "https://ent.recia.fr/ResourceServingWebapp/rs/tango/0.8.90/32x32/categories/preferences-system.png"
+              }
+            }
+          },
+          {
+            "fname": "popular-portlets",
+            "keywords": [],
+            "description": "Liste les portlets qui ont été ajoutées par les utilisateurs",
+            "title": "Applications les plus populaires",
+            "averageRating": 0,
+            "name": "Applications les plus populaires",
+            "ratingsCount": 0,
+            "typeId": 7,
+            "id": 21,
+            "state": "PUBLISHED",
+            "favorite": false,
+            "parameters": {
+              "iconUrl": {
+                "name": "iconUrl",
+                "description": "",
+                "value": "https://ent.recia.fr/ResourceServingWebapp/rs/tango/0.8.90/32x32/categories/preferences-system.png"
+              }
+            }
+          },
+          {
+            "fname": "groupsmanager",
+            "keywords": [],
+            "description": "Gestion des groupes du portail",
+            "title": "Gestion des groupes",
+            "averageRating": 0,
+            "name": "Gestion des groupes",
+            "ratingsCount": 0,
+            "typeId": 7,
+            "id": 12,
+            "state": "PUBLISHED",
+            "favorite": false,
+            "parameters": {
+              "iconUrl": {
+                "name": "iconUrl",
+                "description": "",
+                "value": "https://ent.recia.fr/ResourceServingWebapp/rs/tango/0.8.90/32x32/apps/system-users.png"
+              }
+            }
+          },
+          {
+            "fname": "passwordmgr",
+            "keywords": [],
+            "description": "Gestion des mots de passe",
+            "title": "Gestion des mots de passe",
+            "averageRating": 0,
+            "name": "Gestion des mots de passe",
+            "ratingsCount": 0,
+            "typeId": 7,
+            "id": 18,
+            "state": "PUBLISHED",
+            "favorite": false,
+            "parameters": {
+              "iconUrl": {
+                "name": "iconUrl",
+                "description": "",
+                "value": "https://ent.recia.fr/ResourceServingWebapp/rs/tango/0.8.90/32x32/categories/preferences-system.png"
+              }
+            }
+          },
+          {
+            "fname": "permissionsmanager",
+            "keywords": [],
+            "description": "Portlet de gestion des permissions",
+            "title": "Gestion des permissions",
+            "averageRating": 0,
+            "name": "Gestion des permissions",
+            "ratingsCount": 0,
+            "typeId": 7,
+            "id": 19,
+            "state": "PUBLISHED",
+            "favorite": false,
+            "parameters": {
+              "iconUrl": {
+                "name": "iconUrl",
+                "description": "",
+                "value": "https://ent.recia.fr/ResourceServingWebapp/rs/tango/0.8.90/32x32/categories/preferences-system.png"
+              }
+            }
+          },
+          {
+            "fname": "user-administration",
+            "keywords": [],
+            "description": "Menu des outils de gestion des utilisateurs",
+            "title": "Gestion des utilisateurs",
+            "averageRating": 0,
+            "name": "Gestion des utilisateurs",
+            "ratingsCount": 0,
+            "typeId": 7,
+            "id": 38,
+            "state": "PUBLISHED",
+            "favorite": false,
+            "parameters": {
+              "iconUrl": {
+                "name": "iconUrl",
+                "description": "",
+                "value": "https://ent.recia.fr/ResourceServingWebapp/rs/tango/0.8.90/32x32/apps/system-users.png"
+              }
+            }
+          },
+          {
+            "fname": "statistics",
+            "keywords": [],
+            "description": "Visualiser les statistiques du portail.",
+            "title": "Statistiques",
+            "averageRating": 0,
+            "name": "Statistiques",
+            "ratingsCount": 0,
+            "typeId": 7,
+            "id": 33,
+            "state": "PUBLISHED",
+            "favorite": false,
+            "parameters": {
+              "disableDynamicTitle": {
+                "name": "disableDynamicTitle",
+                "description": "",
+                "value": "true"
+              },
+              "iconUrl": {
+                "name": "iconUrl",
+                "description": "",
+                "value": "https://ent.recia.fr/ResourceServingWebapp/rs/tango/0.8.90/32x32/mimetypes/x-office-spreadsheet.png"
+              }
+            }
+          }
+        ],
+        "subcategories": []
+      }
+    ]
+  }
+}

--- a/@uportal/esco-content-menu/public/layout.json
+++ b/@uportal/esco-content-menu/public/layout.json
@@ -1,1 +1,827 @@
-../../../docs/en/components/esco-content-menu/layout.json
+{
+  "user": "test",
+  "authenticated": "true",
+  "hostname": "my.edu",
+  "fragmentAdmin": "false",
+  "locale": "fr-FR",
+  "layout": {
+    "globals": {
+      "userLayoutRoot": "root",
+      "hasFavorites": "true",
+      "activeTabGroup": "DEFAULT_TABGROUP",
+      "tabsInTabGroup": "1",
+      "userImpersonation": "false"
+    },
+    "regions": [
+      {
+        "name": "header-left",
+        "title": "Header Left folder",
+
+        "folders": [],
+        "content": [
+          {
+            "_objectType": "portlet",
+            "url": "/portail/api/v4-3/portlet/content-menu.html",
+            "iconUrl": "/portail/media/skins/icons/mobile/default.png",
+            "ID": "u16l1n81",
+            "chanID": "120",
+            "description": "Nouveau type de menu",
+            "fragment": "3",
+            "precedence": "80.0",
+            "fname": "content-menu",
+            "locale": "fr_FR",
+            "name": "Menu eyebrow Header",
+            "timeout": "12000",
+            "title": "Menu Header",
+            "typeID": "7",
+            "windowState": "normal",
+            "portletMode": "view",
+            "portletName": "JspInvoker",
+            "lifecycleState": "PUBLISHED",
+            "frameworkPortlet": "true",
+
+            "parameters": {
+              "disableDynamicTitle": "true"
+            }
+          },
+          {
+            "_objectType": "portlet",
+            "url": "/portail/api/v4-3/portlet/project-header-logo.html",
+            "iconUrl": "/portail/media/skins/icons/mobile/default.png",
+            "ID": "u16l1n82",
+            "chanID": "126",
+            "description": "Logo de projet collectivit\u00E9 avec lien sur l'accueil",
+            "fragment": "3",
+            "precedence": "80.0",
+            "fname": "project-header-logo",
+            "locale": "fr_FR",
+            "name": "Project Logo Header",
+            "timeout": "5000",
+            "title": "Project Logo Header",
+            "typeID": "7",
+            "windowState": "normal",
+            "portletMode": "view",
+            "portletName": "JspInvoker",
+            "lifecycleState": "PUBLISHED",
+            "frameworkPortlet": "true",
+
+            "parameters": {
+              "disableDynamicTitle": "true"
+            }
+          },
+          {
+            "_objectType": "portlet",
+            "url": "/portail/api/v4-3/portlet/etablissement-name-header.html",
+            "iconUrl": "/portail/media/skins/icons/mobile/default.png",
+            "ID": "u16l1n83",
+            "chanID": "121",
+            "description": "Afficher l'\u00E9tablissement courant",
+            "fragment": "3",
+            "precedence": "80.0",
+            "fname": "etablissement-name-header",
+            "locale": "fr_FR",
+            "name": "\u00C9tablissement courant Header",
+            "timeout": "15000",
+            "title": "\u00C9tablissement courant Header",
+            "typeID": "7",
+            "windowState": "normal",
+            "portletMode": "view",
+            "portletName": "show-displayName",
+            "lifecycleState": "PUBLISHED",
+            "webAppName": "/change-etablissement",
+
+            "parameters": {
+              "disableDynamicTitle": "true"
+            }
+          },
+          {
+            "_objectType": "portlet",
+            "url": "/portail/api/v4-3/portlet/focused-portlet-header.html",
+            "iconUrl": "/portail/media/skins/icons/mobile/default.png",
+            "ID": "u16l1n84",
+            "chanID": "123",
+            "description": "Afficher le titre de la portlet courante",
+            "fragment": "3",
+            "precedence": "80.0",
+            "fname": "focused-portlet-header",
+            "locale": "fr_FR",
+            "name": "Portlet Courante Header",
+            "timeout": "5000",
+            "title": "Portlet Courante Header",
+            "typeID": "7",
+            "windowState": "normal",
+            "portletMode": "view",
+            "portletName": "JspInvoker",
+            "lifecycleState": "PUBLISHED",
+            "frameworkPortlet": "true",
+
+            "parameters": {
+              "disableDynamicTitle": "true"
+            }
+          }
+        ]
+      },
+      {
+        "name": "footer-second",
+        "title": "Legal Footer",
+
+        "folders": [],
+        "content": [
+          {
+            "_objectType": "portlet",
+            "url": "/portail/api/v4-3/portlet/partners-footer.html",
+            "iconUrl": "/portail/media/skins/icons/mobile/default.png",
+            "ID": "u16l1n610",
+            "chanID": "124",
+            "description": "Partners links for esco-portail",
+            "fragment": "3",
+            "precedence": "80.0",
+            "fname": "partners-footer",
+            "locale": "fr_FR",
+            "name": "Partners Footer",
+            "timeout": "8000",
+            "title": "Partners Footer",
+            "typeID": "7",
+            "windowState": "normal",
+            "portletMode": "view",
+            "portletName": "cms",
+            "lifecycleState": "PUBLISHED",
+            "webAppName": "/SimpleContentPortlet",
+
+            "parameters": {
+              "disableDynamicTitle": "true",
+              "configurable": "true"
+            }
+          }
+        ]
+      },
+      {
+        "name": "page-bottom",
+        "title": "Page Bottom folder",
+
+        "folders": [],
+        "content": [
+          {
+            "_objectType": "portlet",
+            "url": "/portail/api/v4-3/portlet/legal-footer.html",
+            "iconUrl": "/portail/media/skins/icons/mobile/default.png",
+            "ID": "u16l1n710",
+            "chanID": "14",
+            "description": "Legal links for uPortal",
+            "fragment": "3",
+            "precedence": "80.0",
+            "fname": "legal-footer",
+            "locale": "fr_FR",
+            "name": "Legal Footer",
+            "timeout": "8000",
+            "title": "Legal Footer",
+            "typeID": "7",
+            "windowState": "normal",
+            "portletMode": "view",
+            "portletName": "cms",
+            "lifecycleState": "PUBLISHED",
+            "webAppName": "/SimpleContentPortlet",
+
+            "parameters": {
+              "disableDynamicTitle": "true",
+              "configurable": "true"
+            }
+          },
+          {
+            "_objectType": "portlet",
+            "url": "/portail/api/v4-3/portlet/iframe-resizer.html",
+            "iconUrl": "/portail/media/skins/icons/mobile/default.png",
+            "ID": "u16l1n711",
+            "chanID": "130",
+            "description": "Script for the auto-fit of iframes",
+            "fragment": "3",
+            "precedence": "80.0",
+            "fname": "iframe-resizer",
+            "locale": "fr_FR",
+            "name": "Iframe Resizer",
+            "timeout": "8000",
+            "title": "Iframe Resizer",
+            "typeID": "7",
+            "windowState": "normal",
+            "portletMode": "view",
+            "portletName": "cms",
+            "lifecycleState": "PUBLISHED",
+            "webAppName": "/SimpleContentPortlet",
+
+            "parameters": {
+              "disableDynamicTitle": "false",
+              "configurable": "true"
+            }
+          },
+          {
+            "_objectType": "portlet",
+            "url": "/portail/api/v4-3/portlet/browser-detect.html",
+            "iconUrl": "/portail/media/skins/icons/mobile/default.png",
+            "ID": "u16l1n712",
+            "chanID": "128",
+            "description": "D\u00E9tection du navigateur",
+            "fragment": "3",
+            "precedence": "80.0",
+            "fname": "browser-detect",
+            "locale": "fr_FR",
+            "name": "Browser Detection",
+            "timeout": "5000",
+            "title": "Browser Detection",
+            "typeID": "7",
+            "windowState": "normal",
+            "portletMode": "view",
+            "portletName": "JspInvoker",
+            "lifecycleState": "PUBLISHED",
+            "frameworkPortlet": "true",
+
+            "parameters": {
+              "disableDynamicTitle": "true"
+            }
+          },
+          {
+            "_objectType": "portlet",
+            "url": "/portail/api/v4-3/portlet/xiti.html",
+            "iconUrl": "/portail/media/skins/icons/mobile/default.png",
+            "ID": "u17l1n1010",
+            "chanID": "127",
+            "description": "Marqueur Xiti",
+            "fragment": "5",
+            "precedence": "80.0",
+            "fname": "xiti",
+            "locale": "fr_FR",
+            "name": "Marqueur Xiti",
+            "timeout": "10000",
+            "title": "Marqueur Xiti",
+            "typeID": "7",
+            "windowState": "normal",
+            "portletMode": "view",
+            "portletName": "JspInvoker",
+            "lifecycleState": "PUBLISHED",
+            "frameworkPortlet": "true",
+
+            "parameters": {
+              "disableDynamicTitle": "true"
+            }
+          }
+        ]
+      },
+      {
+        "name": "eyebrow",
+        "title": "Eyebrow folder",
+
+        "folders": [],
+        "content": [
+          {
+            "_objectType": "portlet",
+            "url": "/portail/api/v4-3/portlet/eyebrow-user-info.html",
+            "iconUrl": "/portail/media/skins/icons/mobile/default.png",
+            "ID": "u17l1n41",
+            "chanID": "122",
+            "description": "Afficher les informations utilisateur dans l'ent\u00EAte",
+            "fragment": "5",
+            "precedence": "80.0",
+            "fname": "eyebrow-user-info",
+            "locale": "fr_FR",
+            "name": "Informations utilisateur eyebrow Header",
+            "timeout": "12000",
+            "title": "Informations utilisateur Header",
+            "typeID": "7",
+            "windowState": "normal",
+            "portletMode": "view",
+            "portletName": "JspInvoker",
+            "lifecycleState": "PUBLISHED",
+            "frameworkPortlet": "true",
+
+            "parameters": {
+              "disableDynamicTitle": "true"
+            }
+          },
+          {
+            "_objectType": "portlet",
+            "url": "/portail/api/v4-3/portlet/session-timeout.html",
+            "iconUrl": "/portail/media/skins/icons/mobile/default.png",
+            "ID": "u17l1n42",
+            "chanID": "31",
+            "description": "Provides an alert that will appear before a session timeout, giving the user the opportunity to refresh their session.",
+            "fragment": "5",
+            "precedence": "80.0",
+            "fname": "session-timeout",
+            "locale": "fr_FR",
+            "name": "Session Timeout",
+            "timeout": "30000",
+            "title": "Session Timeout",
+            "typeID": "7",
+            "windowState": "normal",
+            "portletMode": "view",
+            "portletName": "SessionTimeout",
+            "lifecycleState": "PUBLISHED",
+            "frameworkPortlet": "true",
+
+            "parameters": {}
+          }
+        ]
+      },
+      {
+        "name": "mezzanine",
+        "title": "Mezzanine folder",
+
+        "folders": [],
+        "content": [
+          {
+            "_objectType": "portlet",
+            "url": "/portail/api/v4-3/portlet/FlashInfoEtab.html",
+            "iconUrl": "/images/portlet_icons/FlashInfoEtab.svg",
+            "ID": "u17l1n201",
+            "chanID": "61",
+            "description": "Les \"Flash Info\" de l'\u00E9tablissement courant                                                                    informations, flash-information, lyc\u00E9e, coll\u00E8ge, CFA, ITS, br\u00E8ves, annonces, nouvelles, actualit\u00E9s",
+            "fragment": "5",
+            "precedence": "80.0",
+            "fname": "FlashInfoEtab",
+            "locale": "fr_FR",
+            "name": "Flash Info de l'\u00E9tablissement",
+            "timeout": "120000",
+            "title": "Flash Info de l'\u00E9tablissement",
+            "typeID": "7",
+            "windowState": "normal",
+            "portletMode": "view",
+            "portletName": "flash-info-portlet",
+            "lifecycleState": "PUBLISHED",
+            "webAppName": "/flash-info-portlet",
+
+            "parameters": {
+              "hideFromDesktop": "false",
+              "blockImpersonation": "false",
+              "locale": "false",
+              "secure": "false",
+              "hideFromMobile": "false",
+              "highlight": "false",
+              "iconUrl": "/images/portlet_icons/FlashInfoEtab.svg",
+              "showChrome": "true",
+              "mobileIconUrl": "/images/portlet_icons/FlashInfoEtab.svg",
+              "hasAbout": "false",
+              "editable": "false",
+              "alternate": "false",
+              "disableDynamicTitle": "true",
+              "printable": "false",
+              "hasHelp": "false"
+            }
+          },
+          {
+            "_objectType": "portlet",
+            "url": "/portail/api/v4-3/portlet/HelpInfo.html",
+            "iconUrl": "/images/portlet_icons/HelpInfo.svg",
+            "ID": "u17l1n202",
+            "chanID": "73",
+            "description": "Aide \u00E0 la prise en main du nouveau portail",
+            "fragment": "5",
+            "precedence": "80.0",
+            "fname": "HelpInfo",
+            "locale": "fr_FR",
+            "name": "Aide du nouveau portail",
+            "timeout": "12000",
+            "title": "Aide du nouveau portail",
+            "typeID": "7",
+            "windowState": "normal",
+            "portletMode": "view",
+            "portletName": "help-info-portlet",
+            "lifecycleState": "PUBLISHED",
+            "webAppName": "/help-info-portlet",
+
+            "parameters": {
+              "hideFromDesktop": "false",
+              "blockImpersonation": "false",
+              "locale": "false",
+              "secure": "false",
+              "hideFromMobile": "false",
+              "highlight": "false",
+              "iconUrl": "/images/portlet_icons/HelpInfo.svg",
+              "showChrome": "false",
+              "mobileIconUrl": "/images/portlet_icons/HelpInfo.svg",
+              "hasAbout": "false",
+              "editable": "false",
+              "alternate": "false",
+              "disableDynamicTitle": "true",
+              "printable": "false",
+              "hasHelp": "false"
+            }
+          }
+        ]
+      }
+    ],
+    "navigation": {
+      "allowAddTab": "true",
+
+      "tabGroupsList": {
+        "activeTabGroup": "DEFAULT_TABGROUP",
+
+        "tabGroups": [
+          {
+            "name": "DEFAULT_TABGROUP",
+            "firstTabId": "u17l1s400"
+          }
+        ]
+      },
+      "tabs": [
+        {
+          "ID": "u17l1s400",
+          "addChildAllowed": "false",
+          "deleteAllowed": "false",
+          "editAllowed": "false",
+          "fragment": "5",
+          "moveAllowed": "false",
+          "precedence": "80.0",
+          "hidden": "false",
+          "immutable": "false",
+          "locale": "fr_FR",
+          "name": "Accueil",
+          "type": "regular",
+          "unremovable": "false",
+          "externalId": "accueil",
+          "tabGroup": "DEFAULT_TABGROUP",
+          "width": "100%",
+
+          "content": [
+            {
+              "_objectType": "folder",
+              "ID": "u17l1s401",
+              "addChildAllowed": "false",
+              "deleteAllowed": "false",
+              "editAllowed": "false",
+              "fragment": "5",
+              "moveAllowed": "false",
+              "precedence": "80.0",
+              "hidden": "false",
+              "immutable": "false",
+              "locale": "fr_FR",
+              "name": "Column",
+              "type": "regular",
+              "unremovable": "false",
+              "tabGroup": "DEFAULT_TABGROUP",
+              "width": "50%",
+
+              "content": [
+                {
+                  "_objectType": "portlet",
+                  "url": "/portail/api/v4-3/portlet/ResumeActualitesEtab.html",
+                  "iconUrl": "/images/portlet_icons/ResumeActualitesEtab.svg",
+                  "ID": "u17l1n402",
+                  "chanID": "94",
+                  "description": "Les derni\u00E8res actualit\u00E9s propos\u00E9es par l'\u00E9tablissement                                                       lyc\u00E9e, coll\u00E8ge, CFA, ITS, nouvelles, annonces",
+                  "deleteAllowed": "false",
+                  "fragment": "5",
+                  "moveAllowed": "false",
+                  "precedence": "80.0",
+                  "fname": "ResumeActualitesEtab",
+                  "locale": "fr_FR",
+                  "name": "Derni\u00E8res actualit\u00E9s de l'\u00E9tablissement",
+                  "timeout": "120000",
+                  "title": "Derni\u00E8res actualit\u00E9s de l'\u00E9tablissement",
+                  "typeID": "7",
+                  "windowState": "normal",
+                  "portletMode": "view",
+                  "portletName": "esup-lecture",
+                  "lifecycleState": "PUBLISHED",
+                  "webAppName": "/esup-lecture",
+
+                  "parameters": {
+                    "hideFromDesktop": "false",
+                    "blockImpersonation": "false",
+                    "locale": "false",
+                    "secure": "false",
+                    "hideFromMobile": "false",
+                    "highlight": "false",
+                    "iconUrl": "/images/portlet_icons/ResumeActualitesEtab.svg",
+                    "showChrome": "true",
+                    "mobileIconUrl": "/images/portlet_icons/ResumeActualitesEtab.svg",
+                    "hasAbout": "false",
+                    "editable": "false",
+                    "alternate": "false",
+                    "disableDynamicTitle": "true",
+                    "printable": "false",
+                    "hasHelp": "false"
+                  }
+                }
+              ]
+            },
+            {
+              "_objectType": "folder",
+              "ID": "u17l1s421",
+              "addChildAllowed": "false",
+              "deleteAllowed": "false",
+              "editAllowed": "false",
+              "fragment": "5",
+              "moveAllowed": "false",
+              "precedence": "80.0",
+              "hidden": "false",
+              "immutable": "false",
+              "locale": "fr_FR",
+              "name": "Column",
+              "type": "regular",
+              "unremovable": "false",
+              "tabGroup": "DEFAULT_TABGROUP",
+              "width": "50%",
+
+              "content": [
+                {
+                  "_objectType": "portlet",
+                  "url": "/portail/api/v4-3/portlet/ResumeInfosENT.html",
+                  "iconUrl": "/images/portlet_icons/ResumeInfosENT",
+                  "ID": "u17l1n403",
+                  "chanID": "96",
+                  "description": "Les derni\u00E8res informations du GIP RECIA pour les administrateurs                                             actualit\u00E9s, ENT, GSI, GIP RECIA, incidents, nouvelles, annonces",
+                  "deleteAllowed": "false",
+                  "fragment": "5",
+                  "moveAllowed": "false",
+                  "precedence": "80.0",
+                  "fname": "ResumeInfosENT",
+                  "locale": "fr_FR",
+                  "name": "Derni\u00E8res informations administrateurs",
+                  "timeout": "120000",
+                  "title": "Derni\u00E8res informations administrateurs",
+                  "typeID": "7",
+                  "windowState": "normal",
+                  "portletMode": "view",
+                  "portletName": "esup-lecture",
+                  "lifecycleState": "PUBLISHED",
+                  "webAppName": "/esup-lecture",
+
+                  "parameters": {
+                    "hideFromDesktop": "false",
+                    "blockImpersonation": "false",
+                    "locale": "false",
+                    "secure": "false",
+                    "hideFromMobile": "false",
+                    "highlight": "false",
+                    "iconUrl": "/images/portlet_icons/ResumeInfosENT",
+                    "showChrome": "true",
+                    "mobileIconUrl": "/images/portlet_icons/ResumeInfosENT",
+                    "hasAbout": "false",
+                    "editable": "false",
+                    "alternate": "false",
+                    "disableDynamicTitle": "true",
+                    "printable": "false",
+                    "hasHelp": "false"
+                  }
+                },
+                {
+                  "_objectType": "portlet",
+                  "url": "/portail/api/v4-3/portlet/AidePortailENT.html",
+                  "iconUrl": "/images/portlet_icons/AidePortailENT.svg",
+                  "ID": "u17l1n424",
+                  "chanID": "131",
+                  "description": "Aide g\u00E9n\u00E9rale pour la prise en main de l'ENT                                                                 assistance, aide en ligne, portail, favoris, menus, applications, services, documentations, mot de passe, initialisation, compte, connexion",
+                  "deleteAllowed": "false",
+                  "fragment": "5",
+                  "moveAllowed": "false",
+                  "precedence": "80.0",
+                  "fname": "AidePortailENT",
+                  "locale": "fr_FR",
+                  "name": "Aide du portail ENT",
+                  "timeout": "15000",
+                  "title": "Aide du portail ENT",
+                  "typeID": "7",
+                  "windowState": "normal",
+                  "portletMode": "view",
+                  "portletName": "WebProxyPortlet",
+                  "lifecycleState": "PUBLISHED",
+                  "webAppName": "/WebProxyPortlet",
+
+                  "parameters": {
+                    "hideFromDesktop": "false",
+                    "blockImpersonation": "false",
+                    "locale": "false",
+                    "hideFromMobile": "false",
+                    "iconUrl": "/images/portlet_icons/AidePortailENT.svg",
+                    "disablePortletEvents": "false",
+                    "mobileIconUrl": "/images/portlet_icons/AidePortailENT.svg",
+                    "hasAbout": "false",
+                    "editable": "false",
+                    "alternate": "false",
+                    "disableDynamicTitle": "true",
+                    "configurable": "false",
+                    "hasHelp": "false"
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    "favorites": [
+      {
+        "_objectType": "folder",
+        "ID": "u18l1s5",
+        "deleteAllowed": "false",
+        "fragment": "1",
+        "precedence": "80.0",
+        "hidden": "false",
+        "immutable": "false",
+        "locale": "fr_FR",
+        "name": "Column",
+        "type": "favorite_column",
+        "unremovable": "false",
+        "tabGroup": "DEFAULT_TABGROUP",
+        "width": "100%",
+
+        "content": [
+          {
+            "_objectType": "portlet",
+            "url": "/portail/api/v4-3/portlet/portal-administration.html",
+            "iconUrl": "/portail/media/skins/icons/mobile/default.png",
+            "ID": "n41",
+            "chanID": "23",
+            "description": "Menu des portlets d'administration du portail",
+            "fname": "portal-administration",
+            "locale": "fr_FR",
+            "name": "Administration du portail",
+            "timeout": "50000",
+            "title": "Administration du portail",
+            "typeID": "7",
+            "windowState": "normal",
+            "portletMode": "view",
+            "portletName": "PortalAdministration",
+            "lifecycleState": "PUBLISHED",
+            "frameworkPortlet": "true",
+
+            "parameters": {
+              "iconUrl": "/ResourceServingWebapp/rs/tango/0.8.90/32x32/categories/preferences-system.png"
+            }
+          },
+          {
+            "_objectType": "portlet",
+            "url": "/portail/api/v4-3/portlet/ESCO-GLC.html",
+            "iconUrl": "/images/portlet_icons/ESCO-GLC.svg",
+            "ID": "n61",
+            "chanID": "57",
+            "description": "Gestion des comptes de l'ENT (comptes ENT, comptes locaux, rattachement de comptes externes, compl\u00E9ment sur les comptes \u00E9tablissement, exports, ...) administration, administrateur, mot de passe, activation, r\u00E9initialisation, utilisateurs, d\u00E9blocage",
+            "fname": "ESCO-GLC",
+            "locale": "fr_FR",
+            "name": "Gestion locale des comptes ENT",
+            "timeout": "5000",
+            "title": "Gestion des comptes",
+            "typeID": "6",
+            "windowState": "normal",
+            "portletMode": "view",
+            "portletName": "IFrame",
+            "lifecycleState": "PUBLISHED",
+            "frameworkPortlet": "true",
+
+            "parameters": {
+              "hideFromDesktop": "false",
+              "blockImpersonation": "true",
+              "locale": "false",
+              "secure": "false",
+              "hideFromMobile": "false",
+              "highlight": "false",
+              "iconUrl": "/images/portlet_icons/ESCO-GLC.svg",
+              "showChrome": "true",
+              "mobileIconUrl": "/images/portlet_icons/ESCO-GLC.svg",
+              "hasAbout": "false",
+              "editable": "false",
+              "alternate": "false",
+              "printable": "false",
+              "hasHelp": "false"
+            }
+          },
+          {
+            "_objectType": "portlet",
+            "url": "/portail/api/v4-3/portlet/ESCO-ParamEtab.html",
+            "iconUrl": "/images/portlet_icons/ESCO-ParamEtab.svg",
+            "ID": "n95",
+            "chanID": "133",
+            "description": "Param\u00E9trage de certains \u00E9l\u00E9ments propres \u00E0 l'\u00E9tablissement pour le portail ENT (nom court, logo)             administration, administrateur, lyc\u00E9e, coll\u00E8ge, CFA, ITS, nom long, personnalisation",
+            "fname": "ESCO-ParamEtab",
+            "locale": "fr_FR",
+            "name": "Param\u00E9trage \u00E9tablissement",
+            "timeout": "5000",
+            "title": "Param\u00E9trage \u00E9tablissement",
+            "typeID": "6",
+            "windowState": "normal",
+            "portletMode": "view",
+            "portletName": "IFrame",
+            "lifecycleState": "PUBLISHED",
+            "frameworkPortlet": "true",
+
+            "parameters": {
+              "hideFromDesktop": "false",
+              "blockImpersonation": "true",
+              "locale": "false",
+              "secure": "false",
+              "hideFromMobile": "false",
+              "highlight": "false",
+              "iconUrl": "/images/portlet_icons/ESCO-ParamEtab.svg",
+              "chromeStyle": "default",
+              "disablePortletEvents": "false",
+              "showChrome": "true",
+              "mobileIconUrl": "/images/portlet_icons/ESCO-ParamEtab.svg",
+              "hasAbout": "false",
+              "editable": "false",
+              "alternate": "false",
+              "disableDynamicTitle": "true",
+              "printable": "false",
+              "configurable": "false",
+              "hasHelp": "false"
+            }
+          },
+          {
+            "_objectType": "portlet",
+            "url": "/portail/api/v4-3/portlet/esup-filemanager.html",
+            "iconUrl": "/images/portlet_icons/esup-filemanager.svg",
+            "ID": "n177",
+            "chanID": "116",
+            "description": "Acc\u00E8s aux espaces de fichiers p\u00E9dagogiques de l'\u00E9tablissement                                                stocker, fichiers, r\u00E9pertoires, partage, partager, consultation, consulter",
+            "fname": "esup-filemanager",
+            "locale": "fr_FR",
+            "name": "Espaces de stockage",
+            "timeout": "3600000",
+            "title": "Espaces de stockage",
+            "typeID": "7",
+            "windowState": "normal",
+            "portletMode": "view",
+            "portletName": "esup-filemanager",
+            "lifecycleState": "PUBLISHED",
+            "webAppName": "/esup-filemanager",
+
+            "parameters": {
+              "hideFromDesktop": "false",
+              "blockImpersonation": "false",
+              "locale": "false",
+              "secure": "false",
+              "hideFromMobile": "false",
+              "highlight": "false",
+              "iconUrl": "/images/portlet_icons/esup-filemanager.svg",
+              "showChrome": "true",
+              "mobileIconUrl": "/images/portlet_icons/esup-filemanager.svg",
+              "hasAbout": "false",
+              "editable": "false",
+              "alternate": "false",
+              "disableDynamicTitle": "true",
+              "printable": "false",
+              "hasHelp": "false"
+            }
+          },
+          {
+            "_objectType": "portlet",
+            "url": "/portail/api/v4-3/portlet/search.html",
+            "iconUrl": "/portail/media/skins/icons/mobile/search.png",
+            "ID": "n349",
+            "chanID": "29",
+            "class": "",
+            "description": "Recherche de contenu dans le portail",
+            "editable": "false",
+            "fname": "search",
+            "hasAbout": "false",
+            "hasHelp": "false",
+            "isPortlet": "true",
+            "name": "Recherche",
+            "secure": "false",
+            "timeout": "30000",
+            "title": "Recherche",
+            "typeID": "7",
+            "windowState": "normal",
+            "portletMode": "view",
+            "portletName": "Search",
+            "lifecycleState": "PUBLISHED",
+            "frameworkPortlet": "true",
+
+            "parameters": {
+              "disableDynamicTitle": "true",
+              "iconUrl": "/ResourceServingWebapp/rs/tango/0.8.90/32x32/actions/system-search.png",
+              "mobileIconUrl": "/portail/media/skins/icons/mobile/search.png"
+            }
+          },
+          {
+            "_objectType": "portlet",
+            "url": "/portail/api/v4-3/portlet/portal-activity.html",
+            "iconUrl": "/portail/media/skins/icons/mobile/default.png",
+            "ID": "n356",
+            "chanID": "22",
+            "class": "",
+            "description": "Afficher l'activit\u00E9 dans le portail",
+            "editable": "false",
+            "fname": "portal-activity",
+            "hasAbout": "false",
+            "hasHelp": "false",
+            "isPortlet": "true",
+            "name": "Activit\u00E9 dans le portail",
+            "secure": "false",
+            "timeout": "50000",
+            "title": "Activit\u00E9 dans le portail",
+            "typeID": "7",
+            "windowState": "normal",
+            "portletMode": "view",
+            "portletName": "PortalActivity",
+            "lifecycleState": "PUBLISHED",
+            "frameworkPortlet": "true",
+
+            "parameters": {
+              "iconUrl": "/ResourceServingWebapp/rs/tango/0.8.90/32x32/categories/preferences-system.png"
+            }
+          }
+        ]
+      }
+    ],
+    "favoriteGroups": []
+  }
+}

--- a/@uportal/esco-content-menu/public/orginfo.json
+++ b/@uportal/esco-content-menu/public/orginfo.json
@@ -1,1 +1,20 @@
-../../../docs/en/components/esco-content-menu/orginfo.json
+{
+  "18450311800020": {
+    "description": "COLLECTIVITE LOCALE",
+    "displayName": "My Organization",
+    "id": "18450311800020",
+    "name": "GIP-RECIA",
+    "otherAttributes": {}
+  },
+  "77551105800056": {
+    "description": "UNIVERSITY",
+    "displayName": "My University",
+    "id": "77551105800056",
+    "name": "My University",
+    "otherAttributes": {
+      "ESCOStructureLogo": [
+        "/annuaire_images/logos/77551105800056/logoportail0.jpg?2"
+      ]
+    }
+  }
+}

--- a/@uportal/esco-content-menu/public/portletRegistry.json
+++ b/@uportal/esco-content-menu/public/portletRegistry.json
@@ -1,1 +1,16534 @@
-../../../docs/en/components/esco-content-menu/portletRegistry.json
+{
+  "registry": {
+    "categories": [
+      {
+        "description": "Toutes les cat\u00e9gories de service",
+        "id": "local.1",
+        "name": "All categories",
+        "portlets": [],
+        "subcategories": [
+          {
+            "description": "Portlets d'administration",
+            "id": "local.10",
+            "name": "Administration",
+            "portlets": [
+              {
+                "averageRating": 0,
+                "description": "Portlet d'administration de fragments",
+                "favorite": false,
+                "fname": "fragment-admin",
+                "id": 10,
+                "keywords": [],
+                "name": "Administration de fragments",
+                "parameters": {
+                  "iconUrl": {
+                    "description": "",
+                    "name": "iconUrl",
+                    "value": "https://ent.recia.fr/ResourceServingWebapp/rs/tango/0.8.90/32x32/categories/applications-system.png"
+                  }
+                },
+                "ratingsCount": 0,
+                "state": "PUBLISHED",
+                "title": "Administration de fragments",
+                "typeId": 7
+              },
+              {
+                "averageRating": 0,
+                "description": "Administration de tenants dans le portail",
+                "favorite": false,
+                "fname": "tenant-portal-administration",
+                "id": 35,
+                "keywords": [],
+                "name": "Administration des tenants",
+                "parameters": {
+                  "configurable": {
+                    "description": "",
+                    "name": "configurable",
+                    "value": "false"
+                  },
+                  "disableDynamicTitle": {
+                    "description": "",
+                    "name": "disableDynamicTitle",
+                    "value": "true"
+                  },
+                  "editable": {
+                    "description": "",
+                    "name": "editable",
+                    "value": "false"
+                  },
+                  "hasAbout": {
+                    "description": "",
+                    "name": "hasAbout",
+                    "value": "false"
+                  },
+                  "hasHelp": {
+                    "description": "",
+                    "name": "hasHelp",
+                    "value": "false"
+                  }
+                },
+                "ratingsCount": 0,
+                "state": "PUBLISHED",
+                "title": "Administration des tenants",
+                "typeId": 7
+              },
+              {
+                "averageRating": 0,
+                "description": "Permet aux administrateurs de voir les fragments de profils dans le portail, leurs propri\u00e9taires, ordres et publics",
+                "favorite": false,
+                "fname": "fragment-audit",
+                "id": 11,
+                "keywords": [],
+                "name": "Audit des fragments",
+                "parameters": {
+                  "iconUrl": {
+                    "description": "",
+                    "name": "iconUrl",
+                    "value": "https://ent.recia.fr/ResourceServingWebapp/rs/tango/0.8.90/32x32/categories/applications-system.png"
+                  }
+                },
+                "ratingsCount": 0,
+                "state": "PUBLISHED",
+                "title": "Audit des fragments",
+                "typeId": 7
+              },
+              {
+                "averageRating": 0,
+                "description": "",
+                "favorite": false,
+                "fname": "AttributeSwapper",
+                "id": 1,
+                "keywords": [],
+                "name": "Echange d'attributs",
+                "parameters": {
+                  "iconUrl": {
+                    "description": "",
+                    "name": "iconUrl",
+                    "value": "https://ent.recia.fr/ResourceServingWebapp/rs/tango/0.8.90/32x32/categories/applications-system.png"
+                  }
+                },
+                "ratingsCount": 0,
+                "state": "PUBLISHED",
+                "title": "Echange d'attributs",
+                "typeId": 7
+              },
+              {
+                "averageRating": 0,
+                "description": "Interface pour voir et vider les instances d'EhCache configur\u00e9es pour uPortal.",
+                "favorite": false,
+                "fname": "cache-manager",
+                "id": 4,
+                "keywords": [],
+                "name": "Gestion des caches",
+                "parameters": {
+                  "iconUrl": {
+                    "description": "",
+                    "name": "iconUrl",
+                    "value": "https://ent.recia.fr/ResourceServingWebapp/rs/tango/0.8.90/32x32/categories/applications-system.png"
+                  }
+                },
+                "ratingsCount": 0,
+                "state": "PUBLISHED",
+                "title": "Gestion des caches",
+                "typeId": 7
+              },
+              {
+                "averageRating": 0,
+                "description": "Gestion des groupes du portail",
+                "favorite": false,
+                "fname": "groupsmanager",
+                "id": 12,
+                "keywords": [],
+                "name": "Gestion des groupes",
+                "parameters": {
+                  "iconUrl": {
+                    "description": "",
+                    "name": "iconUrl",
+                    "value": "https://ent.recia.fr/ResourceServingWebapp/rs/tango/0.8.90/32x32/apps/system-users.png"
+                  }
+                },
+                "ratingsCount": 0,
+                "state": "PUBLISHED",
+                "title": "Gestion des groupes",
+                "typeId": 7
+              },
+              {
+                "averageRating": 0,
+                "description": "Cr\u00e9er et \u00e9diter les tenants du portail",
+                "favorite": false,
+                "fname": "tenant-manager",
+                "id": 34,
+                "keywords": [],
+                "name": "Gestionnaire de tenants",
+                "parameters": {
+                  "alternate": {
+                    "description": "",
+                    "name": "alternate",
+                    "value": "false"
+                  },
+                  "blockImpersonation": {
+                    "description": "",
+                    "name": "blockImpersonation",
+                    "value": "false"
+                  },
+                  "disableDynamicTitle": {
+                    "description": "",
+                    "name": "disableDynamicTitle",
+                    "value": "true"
+                  },
+                  "editable": {
+                    "description": "",
+                    "name": "editable",
+                    "value": "false"
+                  },
+                  "hasAbout": {
+                    "description": "",
+                    "name": "hasAbout",
+                    "value": "false"
+                  },
+                  "hasHelp": {
+                    "description": "",
+                    "name": "hasHelp",
+                    "value": "false"
+                  },
+                  "hideFromMobile": {
+                    "description": "",
+                    "name": "hideFromMobile",
+                    "value": "false"
+                  },
+                  "highlight": {
+                    "description": "",
+                    "name": "highlight",
+                    "value": "false"
+                  },
+                  "printable": {
+                    "description": "",
+                    "name": "printable",
+                    "value": "false"
+                  },
+                  "showChrome": {
+                    "description": "",
+                    "name": "showChrome",
+                    "value": "true"
+                  }
+                },
+                "ratingsCount": 0,
+                "state": "PUBLISHED",
+                "title": "Gestionnaire de tenants",
+                "typeId": 7
+              },
+              {
+                "averageRating": 0,
+                "description": "Portlet pour quitter l'administration de fragments",
+                "favorite": false,
+                "fname": "fragment-admin-exit",
+                "id": 9,
+                "keywords": [],
+                "name": "Quitter l'administration de fragments",
+                "parameters": {
+                  "iconUrl": {
+                    "description": "",
+                    "name": "iconUrl",
+                    "value": "https://ent.recia.fr/ResourceServingWebapp/rs/tango/0.8.90/32x32/categories/applications-system.png"
+                  }
+                },
+                "ratingsCount": 0,
+                "state": "PUBLISHED",
+                "title": "Quitter l'administration de fragments",
+                "typeId": 7
+              },
+              {
+                "averageRating": 0,
+                "description": "R\u00e9initialiser mon profil avec les onglets et canaux d'origine. Supprime \u00e9galement toutes les pr\u00e9f\u00e9rences portlet.",
+                "favorite": false,
+                "fname": "reset-my-layout",
+                "id": 28,
+                "keywords": [],
+                "name": "R\u00e9initialiser mon profil",
+                "parameters": {
+                  "iconUrl": {
+                    "description": "",
+                    "name": "iconUrl",
+                    "value": "https://ent.recia.fr/ResourceServingWebapp/rs/tango/0.8.90/32x32/categories/applications-system.png"
+                  }
+                },
+                "ratingsCount": 0,
+                "state": "PUBLISHED",
+                "title": "R\u00e9initialiser mon profil",
+                "typeId": 7
+              }
+            ],
+            "subcategories": []
+          },
+          {
+            "description": "Services d'administration ENT",
+            "id": "local.27",
+            "name": "Administration ENT",
+            "portlets": [
+              {
+                "averageRating": 0,
+                "description": "Administration des listes de diffusion de l'\u00e9tablissement                                                    courriel, courrier, \u00e9lectronique, mail, diffusion, diffuser, administrateur, administrer, administrateur",
+                "favorite": false,
+                "fname": "AdminListesDiffusion",
+                "id": 45,
+                "keywords": [],
+                "name": "Administration des listes de diffusion",
+                "parameters": {
+                  "alternate": {
+                    "description": "",
+                    "name": "alternate",
+                    "value": "false"
+                  },
+                  "blockImpersonation": {
+                    "description": "",
+                    "name": "blockImpersonation",
+                    "value": "false"
+                  },
+                  "disableDynamicTitle": {
+                    "description": "",
+                    "name": "disableDynamicTitle",
+                    "value": "true"
+                  },
+                  "editable": {
+                    "description": "",
+                    "name": "editable",
+                    "value": "false"
+                  },
+                  "hasAbout": {
+                    "description": "",
+                    "name": "hasAbout",
+                    "value": "false"
+                  },
+                  "hasHelp": {
+                    "description": "",
+                    "name": "hasHelp",
+                    "value": "false"
+                  },
+                  "hideFromDesktop": {
+                    "description": "",
+                    "name": "hideFromDesktop",
+                    "value": "false"
+                  },
+                  "hideFromMobile": {
+                    "description": "",
+                    "name": "hideFromMobile",
+                    "value": "false"
+                  },
+                  "highlight": {
+                    "description": "",
+                    "name": "highlight",
+                    "value": "false"
+                  },
+                  "iconUrl": {
+                    "description": "",
+                    "name": "iconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/AdminListesDiffusion.svg"
+                  },
+                  "locale": {
+                    "description": "",
+                    "name": "locale",
+                    "value": "false"
+                  },
+                  "mobileIconUrl": {
+                    "description": "",
+                    "name": "mobileIconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/AdminListesDiffusion.svg"
+                  },
+                  "printable": {
+                    "description": "",
+                    "name": "printable",
+                    "value": "false"
+                  },
+                  "secure": {
+                    "description": "",
+                    "name": "secure",
+                    "value": "false"
+                  },
+                  "showChrome": {
+                    "description": "",
+                    "name": "showChrome",
+                    "value": "true"
+                  }
+                },
+                "ratingsCount": 0,
+                "state": "PUBLISHED",
+                "title": "Administration des listes de diffusion",
+                "typeId": 7
+              },
+              {
+                "averageRating": 0,
+                "description": "Les derni\u00e8res informations du GIP RECIA pour les administrateurs                                             actualit\u00e9s, ENT, GSI, GIP RECIA, incidents, nouvelles, annonces",
+                "favorite": false,
+                "fname": "ResumeInfosENT",
+                "id": 96,
+                "keywords": [],
+                "name": "Derni\u00e8res informations administrateurs",
+                "parameters": {
+                  "alternate": {
+                    "description": "",
+                    "name": "alternate",
+                    "value": "false"
+                  },
+                  "blockImpersonation": {
+                    "description": "",
+                    "name": "blockImpersonation",
+                    "value": "false"
+                  },
+                  "disableDynamicTitle": {
+                    "description": "",
+                    "name": "disableDynamicTitle",
+                    "value": "true"
+                  },
+                  "editable": {
+                    "description": "",
+                    "name": "editable",
+                    "value": "false"
+                  },
+                  "hasAbout": {
+                    "description": "",
+                    "name": "hasAbout",
+                    "value": "false"
+                  },
+                  "hasHelp": {
+                    "description": "",
+                    "name": "hasHelp",
+                    "value": "false"
+                  },
+                  "hideFromDesktop": {
+                    "description": "",
+                    "name": "hideFromDesktop",
+                    "value": "false"
+                  },
+                  "hideFromMobile": {
+                    "description": "",
+                    "name": "hideFromMobile",
+                    "value": "false"
+                  },
+                  "highlight": {
+                    "description": "",
+                    "name": "highlight",
+                    "value": "false"
+                  },
+                  "iconUrl": {
+                    "description": "",
+                    "name": "iconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/ResumeInfosENT"
+                  },
+                  "locale": {
+                    "description": "",
+                    "name": "locale",
+                    "value": "false"
+                  },
+                  "mobileIconUrl": {
+                    "description": "",
+                    "name": "mobileIconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/ResumeInfosENT"
+                  },
+                  "printable": {
+                    "description": "",
+                    "name": "printable",
+                    "value": "false"
+                  },
+                  "secure": {
+                    "description": "",
+                    "name": "secure",
+                    "value": "false"
+                  },
+                  "showChrome": {
+                    "description": "",
+                    "name": "showChrome",
+                    "value": "true"
+                  }
+                },
+                "ratingsCount": 1,
+                "state": "PUBLISHED",
+                "title": "Derni\u00e8res informations administrateurs",
+                "typeId": 7
+              },
+              {
+                "averageRating": 0,
+                "description": "Documentations de l'ENT \u00e0 destination des administrateurs, directeurs, etc ...                                 administration, administrateur, informations, notices,  portail, applications, services, aide, assistance",
+                "favorite": false,
+                "fname": "DocENT",
+                "id": 54,
+                "keywords": [],
+                "name": "Documentations ENT",
+                "parameters": {
+                  "alternate": {
+                    "description": "",
+                    "name": "alternate",
+                    "value": "false"
+                  },
+                  "blockImpersonation": {
+                    "description": "",
+                    "name": "blockImpersonation",
+                    "value": "false"
+                  },
+                  "disableDynamicTitle": {
+                    "description": "",
+                    "name": "disableDynamicTitle",
+                    "value": "true"
+                  },
+                  "editable": {
+                    "description": "",
+                    "name": "editable",
+                    "value": "false"
+                  },
+                  "hasAbout": {
+                    "description": "",
+                    "name": "hasAbout",
+                    "value": "false"
+                  },
+                  "hasHelp": {
+                    "description": "",
+                    "name": "hasHelp",
+                    "value": "false"
+                  },
+                  "hideFromDesktop": {
+                    "description": "",
+                    "name": "hideFromDesktop",
+                    "value": "false"
+                  },
+                  "hideFromMobile": {
+                    "description": "",
+                    "name": "hideFromMobile",
+                    "value": "false"
+                  },
+                  "highlight": {
+                    "description": "",
+                    "name": "highlight",
+                    "value": "false"
+                  },
+                  "iconUrl": {
+                    "description": "",
+                    "name": "iconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/DocENT.svg"
+                  },
+                  "locale": {
+                    "description": "",
+                    "name": "locale",
+                    "value": "false"
+                  },
+                  "mobileIconUrl": {
+                    "description": "",
+                    "name": "mobileIconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/DocENT.svg"
+                  },
+                  "printable": {
+                    "description": "",
+                    "name": "printable",
+                    "value": "false"
+                  },
+                  "secure": {
+                    "description": "",
+                    "name": "secure",
+                    "value": "false"
+                  },
+                  "showChrome": {
+                    "description": "",
+                    "name": "showChrome",
+                    "value": "true"
+                  }
+                },
+                "ratingsCount": 0,
+                "state": "PUBLISHED",
+                "title": "Documentations ENT",
+                "typeId": 7
+              },
+              {
+                "averageRating": 0,
+                "description": "Gestion des groupes de l'ENT (Grouper)                                                                       administration, administrateur, utilisateurs, classes, niveaux, enseignements, services, droits, applications, \u00e9tablissement, portail",
+                "favorite": false,
+                "fname": "I2Grouper-UI",
+                "id": 74,
+                "keywords": [],
+                "name": "Gestion de groupes Grouper",
+                "parameters": {
+                  "alternate": {
+                    "description": "",
+                    "name": "alternate",
+                    "value": "false"
+                  },
+                  "blockImpersonation": {
+                    "description": "",
+                    "name": "blockImpersonation",
+                    "value": "true"
+                  },
+                  "editable": {
+                    "description": "",
+                    "name": "editable",
+                    "value": "false"
+                  },
+                  "hasAbout": {
+                    "description": "",
+                    "name": "hasAbout",
+                    "value": "false"
+                  },
+                  "hasHelp": {
+                    "description": "",
+                    "name": "hasHelp",
+                    "value": "false"
+                  },
+                  "hideFromDesktop": {
+                    "description": "",
+                    "name": "hideFromDesktop",
+                    "value": "false"
+                  },
+                  "hideFromMobile": {
+                    "description": "",
+                    "name": "hideFromMobile",
+                    "value": "false"
+                  },
+                  "highlight": {
+                    "description": "",
+                    "name": "highlight",
+                    "value": "false"
+                  },
+                  "iconUrl": {
+                    "description": "",
+                    "name": "iconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/I2Grouper-UI.svg"
+                  },
+                  "locale": {
+                    "description": "",
+                    "name": "locale",
+                    "value": "false"
+                  },
+                  "mobileIconUrl": {
+                    "description": "",
+                    "name": "mobileIconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/I2Grouper-UI.svg"
+                  },
+                  "printable": {
+                    "description": "",
+                    "name": "printable",
+                    "value": "false"
+                  },
+                  "secure": {
+                    "description": "",
+                    "name": "secure",
+                    "value": "false"
+                  },
+                  "showChrome": {
+                    "description": "",
+                    "name": "showChrome",
+                    "value": "true"
+                  }
+                },
+                "ratingsCount": 0,
+                "state": "PUBLISHED",
+                "title": "Gestion des groupes",
+                "typeId": 6
+              },
+              {
+                "averageRating": 0,
+                "description": "Gestion des comptes de l'ENT (comptes ENT, comptes locaux, rattachement de comptes externes, compl\u00e9ment sur les comptes \u00e9tablissement, exports, ...) administration, administrateur, mot de passe, activation, r\u00e9initialisation, utilisateurs, d\u00e9blocage",
+                "favorite": true,
+                "fname": "ESCO-GLC",
+                "id": 57,
+                "keywords": [],
+                "name": "Gestion locale des comptes ENT",
+                "parameters": {
+                  "alternate": {
+                    "description": "",
+                    "name": "alternate",
+                    "value": "false"
+                  },
+                  "blockImpersonation": {
+                    "description": "",
+                    "name": "blockImpersonation",
+                    "value": "true"
+                  },
+                  "editable": {
+                    "description": "",
+                    "name": "editable",
+                    "value": "false"
+                  },
+                  "hasAbout": {
+                    "description": "",
+                    "name": "hasAbout",
+                    "value": "false"
+                  },
+                  "hasHelp": {
+                    "description": "",
+                    "name": "hasHelp",
+                    "value": "false"
+                  },
+                  "hideFromDesktop": {
+                    "description": "",
+                    "name": "hideFromDesktop",
+                    "value": "false"
+                  },
+                  "hideFromMobile": {
+                    "description": "",
+                    "name": "hideFromMobile",
+                    "value": "false"
+                  },
+                  "highlight": {
+                    "description": "",
+                    "name": "highlight",
+                    "value": "false"
+                  },
+                  "iconUrl": {
+                    "description": "",
+                    "name": "iconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/ESCO-GLC.svg"
+                  },
+                  "locale": {
+                    "description": "",
+                    "name": "locale",
+                    "value": "false"
+                  },
+                  "mobileIconUrl": {
+                    "description": "",
+                    "name": "mobileIconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/ESCO-GLC.svg"
+                  },
+                  "printable": {
+                    "description": "",
+                    "name": "printable",
+                    "value": "false"
+                  },
+                  "secure": {
+                    "description": "",
+                    "name": "secure",
+                    "value": "false"
+                  },
+                  "showChrome": {
+                    "description": "",
+                    "name": "showChrome",
+                    "value": "true"
+                  }
+                },
+                "ratingsCount": 0,
+                "state": "PUBLISHED",
+                "title": "Gestion des comptes",
+                "typeId": 6
+              },
+              {
+                "averageRating": 0,
+                "description": "Statistiques sur les usages de l'ENT                                                                         indicateurs, usages, suivi, \u00e9tablissement",
+                "favorite": false,
+                "fname": "Statistiques",
+                "id": 104,
+                "keywords": [],
+                "name": "Indicateurs d'usage",
+                "parameters": {
+                  "alternate": {
+                    "description": "",
+                    "name": "alternate",
+                    "value": "false"
+                  },
+                  "blockImpersonation": {
+                    "description": "",
+                    "name": "blockImpersonation",
+                    "value": "true"
+                  },
+                  "editable": {
+                    "description": "",
+                    "name": "editable",
+                    "value": "false"
+                  },
+                  "hasAbout": {
+                    "description": "",
+                    "name": "hasAbout",
+                    "value": "false"
+                  },
+                  "hasHelp": {
+                    "description": "",
+                    "name": "hasHelp",
+                    "value": "false"
+                  },
+                  "hideFromDesktop": {
+                    "description": "",
+                    "name": "hideFromDesktop",
+                    "value": "false"
+                  },
+                  "hideFromMobile": {
+                    "description": "",
+                    "name": "hideFromMobile",
+                    "value": "false"
+                  },
+                  "highlight": {
+                    "description": "",
+                    "name": "highlight",
+                    "value": "false"
+                  },
+                  "iconUrl": {
+                    "description": "",
+                    "name": "iconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/Statistiques.svg"
+                  },
+                  "locale": {
+                    "description": "",
+                    "name": "locale",
+                    "value": "false"
+                  },
+                  "mobileIconUrl": {
+                    "description": "",
+                    "name": "mobileIconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/Statistiques.svg"
+                  },
+                  "printable": {
+                    "description": "",
+                    "name": "printable",
+                    "value": "false"
+                  },
+                  "secure": {
+                    "description": "",
+                    "name": "secure",
+                    "value": "false"
+                  },
+                  "showChrome": {
+                    "description": "",
+                    "name": "showChrome",
+                    "value": "true"
+                  }
+                },
+                "ratingsCount": 0,
+                "state": "PUBLISHED",
+                "title": "Indicateurs d'usage",
+                "typeId": 6
+              },
+              {
+                "averageRating": 0,
+                "description": "Actualit\u00e9s du GIP RECIA \u00e0 destination des admnistrateurs ENT                                                 actualit\u00e9s, ENT, GSI, GIP RECIA, incidents, nouvelles, annonces",
+                "favorite": false,
+                "fname": "AnnoncesRECIA",
+                "id": 47,
+                "keywords": [],
+                "name": "Information administrateurs",
+                "parameters": {
+                  "alternate": {
+                    "description": "",
+                    "name": "alternate",
+                    "value": "false"
+                  },
+                  "blockImpersonation": {
+                    "description": "",
+                    "name": "blockImpersonation",
+                    "value": "false"
+                  },
+                  "disableDynamicTitle": {
+                    "description": "",
+                    "name": "disableDynamicTitle",
+                    "value": "true"
+                  },
+                  "editable": {
+                    "description": "",
+                    "name": "editable",
+                    "value": "false"
+                  },
+                  "hasAbout": {
+                    "description": "",
+                    "name": "hasAbout",
+                    "value": "false"
+                  },
+                  "hasHelp": {
+                    "description": "",
+                    "name": "hasHelp",
+                    "value": "false"
+                  },
+                  "hideFromDesktop": {
+                    "description": "",
+                    "name": "hideFromDesktop",
+                    "value": "false"
+                  },
+                  "hideFromMobile": {
+                    "description": "",
+                    "name": "hideFromMobile",
+                    "value": "false"
+                  },
+                  "highlight": {
+                    "description": "",
+                    "name": "highlight",
+                    "value": "false"
+                  },
+                  "iconUrl": {
+                    "description": "",
+                    "name": "iconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/AnnoncesRECIA.svg"
+                  },
+                  "locale": {
+                    "description": "",
+                    "name": "locale",
+                    "value": "false"
+                  },
+                  "mobileIconUrl": {
+                    "description": "",
+                    "name": "mobileIconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/AnnoncesRECIA.svg"
+                  },
+                  "printable": {
+                    "description": "",
+                    "name": "printable",
+                    "value": "false"
+                  },
+                  "secure": {
+                    "description": "",
+                    "name": "secure",
+                    "value": "false"
+                  },
+                  "showChrome": {
+                    "description": "",
+                    "name": "showChrome",
+                    "value": "true"
+                  }
+                },
+                "ratingsCount": 0,
+                "state": "PUBLISHED",
+                "title": "Information administrateurs",
+                "typeId": 7
+              },
+              {
+                "averageRating": 0,
+                "description": "Param\u00e9trage de certains \u00e9l\u00e9ments propres \u00e0 l'\u00e9tablissement pour le portail ENT (nom court, logo)             administration, administrateur, lyc\u00e9e, coll\u00e8ge, CFA, ITS, nom long, personnalisation",
+                "favorite": true,
+                "fname": "ESCO-ParamEtab",
+                "id": 133,
+                "keywords": [],
+                "name": "Param\u00e9trage \u00e9tablissement",
+                "parameters": {
+                  "alternate": {
+                    "description": "",
+                    "name": "alternate",
+                    "value": "false"
+                  },
+                  "blockImpersonation": {
+                    "description": "",
+                    "name": "blockImpersonation",
+                    "value": "true"
+                  },
+                  "chromeStyle": {
+                    "description": "",
+                    "name": "chromeStyle",
+                    "value": "default"
+                  },
+                  "configurable": {
+                    "description": "",
+                    "name": "configurable",
+                    "value": "false"
+                  },
+                  "disableDynamicTitle": {
+                    "description": "",
+                    "name": "disableDynamicTitle",
+                    "value": "true"
+                  },
+                  "disablePortletEvents": {
+                    "description": "",
+                    "name": "disablePortletEvents",
+                    "value": "false"
+                  },
+                  "editable": {
+                    "description": "",
+                    "name": "editable",
+                    "value": "false"
+                  },
+                  "hasAbout": {
+                    "description": "",
+                    "name": "hasAbout",
+                    "value": "false"
+                  },
+                  "hasHelp": {
+                    "description": "",
+                    "name": "hasHelp",
+                    "value": "false"
+                  },
+                  "hideFromDesktop": {
+                    "description": "",
+                    "name": "hideFromDesktop",
+                    "value": "false"
+                  },
+                  "hideFromMobile": {
+                    "description": "",
+                    "name": "hideFromMobile",
+                    "value": "false"
+                  },
+                  "highlight": {
+                    "description": "",
+                    "name": "highlight",
+                    "value": "false"
+                  },
+                  "iconUrl": {
+                    "description": "",
+                    "name": "iconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/ESCO-ParamEtab.svg"
+                  },
+                  "locale": {
+                    "description": "",
+                    "name": "locale",
+                    "value": "false"
+                  },
+                  "mobileIconUrl": {
+                    "description": "",
+                    "name": "mobileIconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/ESCO-ParamEtab.svg"
+                  },
+                  "printable": {
+                    "description": "",
+                    "name": "printable",
+                    "value": "false"
+                  },
+                  "secure": {
+                    "description": "",
+                    "name": "secure",
+                    "value": "false"
+                  },
+                  "showChrome": {
+                    "description": "",
+                    "name": "showChrome",
+                    "value": "true"
+                  }
+                },
+                "ratingsCount": 0,
+                "state": "PUBLISHED",
+                "title": "Param\u00e9trage \u00e9tablissement",
+                "typeId": 6
+              },
+              {
+                "averageRating": 0,
+                "description": "Outil de support du GIP RECIA                                                                                  maintenance, administration, administrateur, CSL, Correspondant Support Local, assistance, ordinateur, PC, demande, ticket, suivi, aide",
+                "favorite": false,
+                "fname": "ITSM",
+                "id": 75,
+                "keywords": [],
+                "name": "Portail des requ\u00eates (iTop)",
+                "parameters": {
+                  "alternate": {
+                    "description": "",
+                    "name": "alternate",
+                    "value": "false"
+                  },
+                  "alternativeMaximizedLink": {
+                    "description": "",
+                    "name": "alternativeMaximizedLink",
+                    "value": "/portail/api/ExternalURLStats?fname=ITSM&service=https://itsm.escolan.recia.fr/pages/UI.php?login_mode=cas"
+                  },
+                  "blockImpersonation": {
+                    "description": "",
+                    "name": "blockImpersonation",
+                    "value": "true"
+                  },
+                  "editable": {
+                    "description": "",
+                    "name": "editable",
+                    "value": "false"
+                  },
+                  "hasAbout": {
+                    "description": "",
+                    "name": "hasAbout",
+                    "value": "false"
+                  },
+                  "hasHelp": {
+                    "description": "",
+                    "name": "hasHelp",
+                    "value": "false"
+                  },
+                  "hideFromDesktop": {
+                    "description": "",
+                    "name": "hideFromDesktop",
+                    "value": "false"
+                  },
+                  "hideFromMobile": {
+                    "description": "",
+                    "name": "hideFromMobile",
+                    "value": "false"
+                  },
+                  "highlight": {
+                    "description": "",
+                    "name": "highlight",
+                    "value": "false"
+                  },
+                  "iconUrl": {
+                    "description": "",
+                    "name": "iconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/ITSM.svg"
+                  },
+                  "locale": {
+                    "description": "",
+                    "name": "locale",
+                    "value": "false"
+                  },
+                  "mobileIconUrl": {
+                    "description": "",
+                    "name": "mobileIconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/ITSM.svg"
+                  },
+                  "printable": {
+                    "description": "",
+                    "name": "printable",
+                    "value": "false"
+                  },
+                  "secure": {
+                    "description": "",
+                    "name": "secure",
+                    "value": "false"
+                  },
+                  "showChrome": {
+                    "description": "",
+                    "name": "showChrome",
+                    "value": "true"
+                  }
+                },
+                "ratingsCount": 0,
+                "state": "PUBLISHED",
+                "title": "Portail des requ\u00eates (iTop)",
+                "typeId": 6
+              },
+              {
+                "averageRating": 0,
+                "description": "Rapport d'execution de l'extraction Wincfa/Ypareo                                                              erreurs, administration, administrateur, Ymag, suivi, alimentation ENT",
+                "favorite": false,
+                "fname": "YmagLog",
+                "id": 108,
+                "keywords": [],
+                "name": "Rapport d'erreurs Ypar\u00e9o",
+                "parameters": {
+                  "blockImpersonation": {
+                    "description": "",
+                    "name": "blockImpersonation",
+                    "value": "true"
+                  },
+                  "editable": {
+                    "description": "",
+                    "name": "editable",
+                    "value": "false"
+                  },
+                  "hasAbout": {
+                    "description": "",
+                    "name": "hasAbout",
+                    "value": "false"
+                  },
+                  "hasHelp": {
+                    "description": "",
+                    "name": "hasHelp",
+                    "value": "false"
+                  },
+                  "hideFromDesktop": {
+                    "description": "",
+                    "name": "hideFromDesktop",
+                    "value": "false"
+                  },
+                  "hideFromMobile": {
+                    "description": "",
+                    "name": "hideFromMobile",
+                    "value": "false"
+                  },
+                  "highlight": {
+                    "description": "",
+                    "name": "highlight",
+                    "value": "false"
+                  },
+                  "iconUrl": {
+                    "description": "",
+                    "name": "iconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/YmagLog.svg"
+                  },
+                  "locale": {
+                    "description": "",
+                    "name": "locale",
+                    "value": "false"
+                  },
+                  "mobileIconUrl": {
+                    "description": "",
+                    "name": "mobileIconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/YmagLog.svg"
+                  },
+                  "printable": {
+                    "description": "",
+                    "name": "printable",
+                    "value": "false"
+                  },
+                  "secure": {
+                    "description": "",
+                    "name": "secure",
+                    "value": "false"
+                  }
+                },
+                "ratingsCount": 0,
+                "state": "PUBLISHED",
+                "title": "Rapport d'erreurs Ypar\u00e9o",
+                "typeId": 6
+              }
+            ],
+            "subcategories": []
+          },
+          {
+            "description": "Services d'aide et d'assistance",
+            "id": "local.28",
+            "name": "Aide - assistance",
+            "portlets": [
+              {
+                "averageRating": 0,
+                "description": "Aide g\u00e9n\u00e9rale pour la prise en main de l'ENT                                                                 assistance, aide en ligne, portail, favoris, menus, applications, services, documentations, mot de passe, initialisation, compte, connexion",
+                "favorite": false,
+                "fname": "AidePortailENT",
+                "id": 131,
+                "keywords": [],
+                "name": "Aide du portail ENT",
+                "parameters": {
+                  "alternate": {
+                    "description": "",
+                    "name": "alternate",
+                    "value": "false"
+                  },
+                  "blockImpersonation": {
+                    "description": "",
+                    "name": "blockImpersonation",
+                    "value": "false"
+                  },
+                  "configurable": {
+                    "description": "",
+                    "name": "configurable",
+                    "value": "false"
+                  },
+                  "disableDynamicTitle": {
+                    "description": "",
+                    "name": "disableDynamicTitle",
+                    "value": "true"
+                  },
+                  "disablePortletEvents": {
+                    "description": "",
+                    "name": "disablePortletEvents",
+                    "value": "false"
+                  },
+                  "editable": {
+                    "description": "",
+                    "name": "editable",
+                    "value": "false"
+                  },
+                  "hasAbout": {
+                    "description": "",
+                    "name": "hasAbout",
+                    "value": "false"
+                  },
+                  "hasHelp": {
+                    "description": "",
+                    "name": "hasHelp",
+                    "value": "false"
+                  },
+                  "hideFromDesktop": {
+                    "description": "",
+                    "name": "hideFromDesktop",
+                    "value": "false"
+                  },
+                  "hideFromMobile": {
+                    "description": "",
+                    "name": "hideFromMobile",
+                    "value": "false"
+                  },
+                  "iconUrl": {
+                    "description": "",
+                    "name": "iconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/AidePortailENT.svg"
+                  },
+                  "locale": {
+                    "description": "",
+                    "name": "locale",
+                    "value": "false"
+                  },
+                  "mobileIconUrl": {
+                    "description": "",
+                    "name": "mobileIconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/AidePortailENT.svg"
+                  }
+                },
+                "ratingsCount": 1,
+                "state": "PUBLISHED",
+                "title": "Aide du portail ENT",
+                "typeId": 7
+              },
+              {
+                "averageRating": 0,
+                "description": "Les derni\u00e8res informations du GIP RECIA pour les administrateurs                                             actualit\u00e9s, ENT, GSI, GIP RECIA, incidents, nouvelles, annonces",
+                "favorite": false,
+                "fname": "ResumeInfosENT",
+                "id": 96,
+                "keywords": [],
+                "name": "Derni\u00e8res informations administrateurs",
+                "parameters": {
+                  "alternate": {
+                    "description": "",
+                    "name": "alternate",
+                    "value": "false"
+                  },
+                  "blockImpersonation": {
+                    "description": "",
+                    "name": "blockImpersonation",
+                    "value": "false"
+                  },
+                  "disableDynamicTitle": {
+                    "description": "",
+                    "name": "disableDynamicTitle",
+                    "value": "true"
+                  },
+                  "editable": {
+                    "description": "",
+                    "name": "editable",
+                    "value": "false"
+                  },
+                  "hasAbout": {
+                    "description": "",
+                    "name": "hasAbout",
+                    "value": "false"
+                  },
+                  "hasHelp": {
+                    "description": "",
+                    "name": "hasHelp",
+                    "value": "false"
+                  },
+                  "hideFromDesktop": {
+                    "description": "",
+                    "name": "hideFromDesktop",
+                    "value": "false"
+                  },
+                  "hideFromMobile": {
+                    "description": "",
+                    "name": "hideFromMobile",
+                    "value": "false"
+                  },
+                  "highlight": {
+                    "description": "",
+                    "name": "highlight",
+                    "value": "false"
+                  },
+                  "iconUrl": {
+                    "description": "",
+                    "name": "iconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/ResumeInfosENT"
+                  },
+                  "locale": {
+                    "description": "",
+                    "name": "locale",
+                    "value": "false"
+                  },
+                  "mobileIconUrl": {
+                    "description": "",
+                    "name": "mobileIconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/ResumeInfosENT"
+                  },
+                  "printable": {
+                    "description": "",
+                    "name": "printable",
+                    "value": "false"
+                  },
+                  "secure": {
+                    "description": "",
+                    "name": "secure",
+                    "value": "false"
+                  },
+                  "showChrome": {
+                    "description": "",
+                    "name": "showChrome",
+                    "value": "true"
+                  }
+                },
+                "ratingsCount": 1,
+                "state": "PUBLISHED",
+                "title": "Derni\u00e8res informations administrateurs",
+                "typeId": 7
+              },
+              {
+                "averageRating": 0,
+                "description": "Documentations de l'ENT \u00e0 destination des administrateurs, directeurs, etc ...                                 administration, administrateur, informations, notices,  portail, applications, services, aide, assistance",
+                "favorite": false,
+                "fname": "DocENT",
+                "id": 54,
+                "keywords": [],
+                "name": "Documentations ENT",
+                "parameters": {
+                  "alternate": {
+                    "description": "",
+                    "name": "alternate",
+                    "value": "false"
+                  },
+                  "blockImpersonation": {
+                    "description": "",
+                    "name": "blockImpersonation",
+                    "value": "false"
+                  },
+                  "disableDynamicTitle": {
+                    "description": "",
+                    "name": "disableDynamicTitle",
+                    "value": "true"
+                  },
+                  "editable": {
+                    "description": "",
+                    "name": "editable",
+                    "value": "false"
+                  },
+                  "hasAbout": {
+                    "description": "",
+                    "name": "hasAbout",
+                    "value": "false"
+                  },
+                  "hasHelp": {
+                    "description": "",
+                    "name": "hasHelp",
+                    "value": "false"
+                  },
+                  "hideFromDesktop": {
+                    "description": "",
+                    "name": "hideFromDesktop",
+                    "value": "false"
+                  },
+                  "hideFromMobile": {
+                    "description": "",
+                    "name": "hideFromMobile",
+                    "value": "false"
+                  },
+                  "highlight": {
+                    "description": "",
+                    "name": "highlight",
+                    "value": "false"
+                  },
+                  "iconUrl": {
+                    "description": "",
+                    "name": "iconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/DocENT.svg"
+                  },
+                  "locale": {
+                    "description": "",
+                    "name": "locale",
+                    "value": "false"
+                  },
+                  "mobileIconUrl": {
+                    "description": "",
+                    "name": "mobileIconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/DocENT.svg"
+                  },
+                  "printable": {
+                    "description": "",
+                    "name": "printable",
+                    "value": "false"
+                  },
+                  "secure": {
+                    "description": "",
+                    "name": "secure",
+                    "value": "false"
+                  },
+                  "showChrome": {
+                    "description": "",
+                    "name": "showChrome",
+                    "value": "true"
+                  }
+                },
+                "ratingsCount": 0,
+                "state": "PUBLISHED",
+                "title": "Documentations ENT",
+                "typeId": 7
+              },
+              {
+                "averageRating": 0,
+                "description": "Actualit\u00e9s du GIP RECIA \u00e0 destination des admnistrateurs ENT                                                 actualit\u00e9s, ENT, GSI, GIP RECIA, incidents, nouvelles, annonces",
+                "favorite": false,
+                "fname": "AnnoncesRECIA",
+                "id": 47,
+                "keywords": [],
+                "name": "Information administrateurs",
+                "parameters": {
+                  "alternate": {
+                    "description": "",
+                    "name": "alternate",
+                    "value": "false"
+                  },
+                  "blockImpersonation": {
+                    "description": "",
+                    "name": "blockImpersonation",
+                    "value": "false"
+                  },
+                  "disableDynamicTitle": {
+                    "description": "",
+                    "name": "disableDynamicTitle",
+                    "value": "true"
+                  },
+                  "editable": {
+                    "description": "",
+                    "name": "editable",
+                    "value": "false"
+                  },
+                  "hasAbout": {
+                    "description": "",
+                    "name": "hasAbout",
+                    "value": "false"
+                  },
+                  "hasHelp": {
+                    "description": "",
+                    "name": "hasHelp",
+                    "value": "false"
+                  },
+                  "hideFromDesktop": {
+                    "description": "",
+                    "name": "hideFromDesktop",
+                    "value": "false"
+                  },
+                  "hideFromMobile": {
+                    "description": "",
+                    "name": "hideFromMobile",
+                    "value": "false"
+                  },
+                  "highlight": {
+                    "description": "",
+                    "name": "highlight",
+                    "value": "false"
+                  },
+                  "iconUrl": {
+                    "description": "",
+                    "name": "iconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/AnnoncesRECIA.svg"
+                  },
+                  "locale": {
+                    "description": "",
+                    "name": "locale",
+                    "value": "false"
+                  },
+                  "mobileIconUrl": {
+                    "description": "",
+                    "name": "mobileIconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/AnnoncesRECIA.svg"
+                  },
+                  "printable": {
+                    "description": "",
+                    "name": "printable",
+                    "value": "false"
+                  },
+                  "secure": {
+                    "description": "",
+                    "name": "secure",
+                    "value": "false"
+                  },
+                  "showChrome": {
+                    "description": "",
+                    "name": "showChrome",
+                    "value": "true"
+                  }
+                },
+                "ratingsCount": 0,
+                "state": "PUBLISHED",
+                "title": "Information administrateurs",
+                "typeId": 7
+              },
+              {
+                "averageRating": 0,
+                "description": "Outil de support du GIP RECIA                                                                                  maintenance, administration, administrateur, CSL, Correspondant Support Local, assistance, ordinateur, PC, demande, ticket, suivi, aide",
+                "favorite": false,
+                "fname": "ITSM",
+                "id": 75,
+                "keywords": [],
+                "name": "Portail des requ\u00eates (iTop)",
+                "parameters": {
+                  "alternate": {
+                    "description": "",
+                    "name": "alternate",
+                    "value": "false"
+                  },
+                  "alternativeMaximizedLink": {
+                    "description": "",
+                    "name": "alternativeMaximizedLink",
+                    "value": "/portail/api/ExternalURLStats?fname=ITSM&service=https://itsm.escolan.recia.fr/pages/UI.php?login_mode=cas"
+                  },
+                  "blockImpersonation": {
+                    "description": "",
+                    "name": "blockImpersonation",
+                    "value": "true"
+                  },
+                  "editable": {
+                    "description": "",
+                    "name": "editable",
+                    "value": "false"
+                  },
+                  "hasAbout": {
+                    "description": "",
+                    "name": "hasAbout",
+                    "value": "false"
+                  },
+                  "hasHelp": {
+                    "description": "",
+                    "name": "hasHelp",
+                    "value": "false"
+                  },
+                  "hideFromDesktop": {
+                    "description": "",
+                    "name": "hideFromDesktop",
+                    "value": "false"
+                  },
+                  "hideFromMobile": {
+                    "description": "",
+                    "name": "hideFromMobile",
+                    "value": "false"
+                  },
+                  "highlight": {
+                    "description": "",
+                    "name": "highlight",
+                    "value": "false"
+                  },
+                  "iconUrl": {
+                    "description": "",
+                    "name": "iconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/ITSM.svg"
+                  },
+                  "locale": {
+                    "description": "",
+                    "name": "locale",
+                    "value": "false"
+                  },
+                  "mobileIconUrl": {
+                    "description": "",
+                    "name": "mobileIconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/ITSM.svg"
+                  },
+                  "printable": {
+                    "description": "",
+                    "name": "printable",
+                    "value": "false"
+                  },
+                  "secure": {
+                    "description": "",
+                    "name": "secure",
+                    "value": "false"
+                  },
+                  "showChrome": {
+                    "description": "",
+                    "name": "showChrome",
+                    "value": "true"
+                  }
+                },
+                "ratingsCount": 0,
+                "state": "PUBLISHED",
+                "title": "Portail des requ\u00eates (iTop)",
+                "typeId": 6
+              }
+            ],
+            "subcategories": []
+          },
+          {
+            "description": "Services li\u00e9s \u00e0 la communication",
+            "id": "local.29",
+            "name": "Communication",
+            "portlets": [
+              {
+                "averageRating": 0,
+                "description": "Actualit\u00e9s en R\u00e9gion Centre-Val de Loire                                                                     nouvelles, annonces",
+                "favorite": false,
+                "fname": "ActualitesRegion",
+                "id": 44,
+                "keywords": [],
+                "name": "Actualit\u00e9s R\u00e9gion",
+                "parameters": {
+                  "alternate": {
+                    "description": "",
+                    "name": "alternate",
+                    "value": "false"
+                  },
+                  "blockImpersonation": {
+                    "description": "",
+                    "name": "blockImpersonation",
+                    "value": "false"
+                  },
+                  "disableDynamicTitle": {
+                    "description": "",
+                    "name": "disableDynamicTitle",
+                    "value": "true"
+                  },
+                  "editable": {
+                    "description": "",
+                    "name": "editable",
+                    "value": "false"
+                  },
+                  "hasAbout": {
+                    "description": "",
+                    "name": "hasAbout",
+                    "value": "false"
+                  },
+                  "hasHelp": {
+                    "description": "",
+                    "name": "hasHelp",
+                    "value": "false"
+                  },
+                  "hideFromDesktop": {
+                    "description": "",
+                    "name": "hideFromDesktop",
+                    "value": "false"
+                  },
+                  "hideFromMobile": {
+                    "description": "",
+                    "name": "hideFromMobile",
+                    "value": "false"
+                  },
+                  "highlight": {
+                    "description": "",
+                    "name": "highlight",
+                    "value": "false"
+                  },
+                  "iconUrl": {
+                    "description": "",
+                    "name": "iconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/ActualitesRegion.svg"
+                  },
+                  "locale": {
+                    "description": "",
+                    "name": "locale",
+                    "value": "false"
+                  },
+                  "mobileIconUrl": {
+                    "description": "",
+                    "name": "mobileIconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/ActualitesRegion.svg"
+                  },
+                  "printable": {
+                    "description": "",
+                    "name": "printable",
+                    "value": "false"
+                  },
+                  "secure": {
+                    "description": "",
+                    "name": "secure",
+                    "value": "false"
+                  },
+                  "showChrome": {
+                    "description": "",
+                    "name": "showChrome",
+                    "value": "true"
+                  }
+                },
+                "ratingsCount": 0,
+                "state": "PUBLISHED",
+                "title": "Actualit\u00e9s en R\u00e9gion",
+                "typeId": 7
+              },
+              {
+                "averageRating": 0,
+                "description": "Les actualit\u00e9s propos\u00e9es par l'\u00e9tablissement                                                                 lyc\u00e9e, coll\u00e8ge, CFA, ITS, nouvelles, annonces",
+                "favorite": false,
+                "fname": "ActualitesEtab",
+                "id": 43,
+                "keywords": [],
+                "name": "Actualit\u00e9s de l'\u00e9tablissement",
+                "parameters": {
+                  "alternate": {
+                    "description": "",
+                    "name": "alternate",
+                    "value": "false"
+                  },
+                  "blockImpersonation": {
+                    "description": "",
+                    "name": "blockImpersonation",
+                    "value": "false"
+                  },
+                  "disableDynamicTitle": {
+                    "description": "",
+                    "name": "disableDynamicTitle",
+                    "value": "true"
+                  },
+                  "editable": {
+                    "description": "",
+                    "name": "editable",
+                    "value": "false"
+                  },
+                  "hasAbout": {
+                    "description": "",
+                    "name": "hasAbout",
+                    "value": "false"
+                  },
+                  "hasHelp": {
+                    "description": "",
+                    "name": "hasHelp",
+                    "value": "false"
+                  },
+                  "hideFromDesktop": {
+                    "description": "",
+                    "name": "hideFromDesktop",
+                    "value": "false"
+                  },
+                  "hideFromMobile": {
+                    "description": "",
+                    "name": "hideFromMobile",
+                    "value": "false"
+                  },
+                  "highlight": {
+                    "description": "",
+                    "name": "highlight",
+                    "value": "false"
+                  },
+                  "iconUrl": {
+                    "description": "",
+                    "name": "iconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/ActualitesEtab.svg"
+                  },
+                  "locale": {
+                    "description": "",
+                    "name": "locale",
+                    "value": "false"
+                  },
+                  "mobileIconUrl": {
+                    "description": "",
+                    "name": "mobileIconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/ActualitesEtab.svg"
+                  },
+                  "printable": {
+                    "description": "",
+                    "name": "printable",
+                    "value": "false"
+                  },
+                  "secure": {
+                    "description": "",
+                    "name": "secure",
+                    "value": "false"
+                  },
+                  "showChrome": {
+                    "description": "",
+                    "name": "showChrome",
+                    "value": "true"
+                  }
+                },
+                "ratingsCount": 0,
+                "state": "PUBLISHED",
+                "title": "Actualit\u00e9s de l'\u00e9tablissement",
+                "typeId": 7
+              },
+              {
+                "averageRating": 0,
+                "description": "Actualit\u00e9s de la Touraine, mon d\u00e9partement                                                                   Indre-et-Loire, nouvelles, annonces",
+                "favorite": false,
+                "fname": "ActualitesCD37",
+                "id": 42,
+                "keywords": [],
+                "name": "Actualit\u00e9s en Touraine",
+                "parameters": {
+                  "alternate": {
+                    "description": "",
+                    "name": "alternate",
+                    "value": "false"
+                  },
+                  "blockImpersonation": {
+                    "description": "",
+                    "name": "blockImpersonation",
+                    "value": "false"
+                  },
+                  "disableDynamicTitle": {
+                    "description": "",
+                    "name": "disableDynamicTitle",
+                    "value": "true"
+                  },
+                  "editable": {
+                    "description": "",
+                    "name": "editable",
+                    "value": "false"
+                  },
+                  "hasAbout": {
+                    "description": "",
+                    "name": "hasAbout",
+                    "value": "false"
+                  },
+                  "hasHelp": {
+                    "description": "",
+                    "name": "hasHelp",
+                    "value": "false"
+                  },
+                  "hideFromDesktop": {
+                    "description": "",
+                    "name": "hideFromDesktop",
+                    "value": "false"
+                  },
+                  "hideFromMobile": {
+                    "description": "",
+                    "name": "hideFromMobile",
+                    "value": "false"
+                  },
+                  "highlight": {
+                    "description": "",
+                    "name": "highlight",
+                    "value": "false"
+                  },
+                  "iconUrl": {
+                    "description": "",
+                    "name": "iconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/ActualitesCD37.svg"
+                  },
+                  "locale": {
+                    "description": "",
+                    "name": "locale",
+                    "value": "false"
+                  },
+                  "mobileIconUrl": {
+                    "description": "",
+                    "name": "mobileIconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/ActualitesCD37.svg"
+                  },
+                  "printable": {
+                    "description": "",
+                    "name": "printable",
+                    "value": "false"
+                  },
+                  "secure": {
+                    "description": "",
+                    "name": "secure",
+                    "value": "false"
+                  },
+                  "showChrome": {
+                    "description": "",
+                    "name": "showChrome",
+                    "value": "false"
+                  }
+                },
+                "ratingsCount": 0,
+                "state": "PUBLISHED",
+                "title": "Actualit\u00e9s en Touraine",
+                "typeId": 7
+              },
+              {
+                "averageRating": 0,
+                "description": "Administration des listes de diffusion de l'\u00e9tablissement                                                    courriel, courrier, \u00e9lectronique, mail, diffusion, diffuser, administrateur, administrer, administrateur",
+                "favorite": false,
+                "fname": "AdminListesDiffusion",
+                "id": 45,
+                "keywords": [],
+                "name": "Administration des listes de diffusion",
+                "parameters": {
+                  "alternate": {
+                    "description": "",
+                    "name": "alternate",
+                    "value": "false"
+                  },
+                  "blockImpersonation": {
+                    "description": "",
+                    "name": "blockImpersonation",
+                    "value": "false"
+                  },
+                  "disableDynamicTitle": {
+                    "description": "",
+                    "name": "disableDynamicTitle",
+                    "value": "true"
+                  },
+                  "editable": {
+                    "description": "",
+                    "name": "editable",
+                    "value": "false"
+                  },
+                  "hasAbout": {
+                    "description": "",
+                    "name": "hasAbout",
+                    "value": "false"
+                  },
+                  "hasHelp": {
+                    "description": "",
+                    "name": "hasHelp",
+                    "value": "false"
+                  },
+                  "hideFromDesktop": {
+                    "description": "",
+                    "name": "hideFromDesktop",
+                    "value": "false"
+                  },
+                  "hideFromMobile": {
+                    "description": "",
+                    "name": "hideFromMobile",
+                    "value": "false"
+                  },
+                  "highlight": {
+                    "description": "",
+                    "name": "highlight",
+                    "value": "false"
+                  },
+                  "iconUrl": {
+                    "description": "",
+                    "name": "iconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/AdminListesDiffusion.svg"
+                  },
+                  "locale": {
+                    "description": "",
+                    "name": "locale",
+                    "value": "false"
+                  },
+                  "mobileIconUrl": {
+                    "description": "",
+                    "name": "mobileIconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/AdminListesDiffusion.svg"
+                  },
+                  "printable": {
+                    "description": "",
+                    "name": "printable",
+                    "value": "false"
+                  },
+                  "secure": {
+                    "description": "",
+                    "name": "secure",
+                    "value": "false"
+                  },
+                  "showChrome": {
+                    "description": "",
+                    "name": "showChrome",
+                    "value": "true"
+                  }
+                },
+                "ratingsCount": 0,
+                "state": "PUBLISHED",
+                "title": "Administration des listes de diffusion",
+                "typeId": 7
+              },
+              {
+                "averageRating": 0,
+                "description": "Aide g\u00e9n\u00e9rale pour la prise en main de l'ENT                                                                 assistance, aide en ligne, portail, favoris, menus, applications, services, documentations, mot de passe, initialisation, compte, connexion",
+                "favorite": false,
+                "fname": "AidePortailENT",
+                "id": 131,
+                "keywords": [],
+                "name": "Aide du portail ENT",
+                "parameters": {
+                  "alternate": {
+                    "description": "",
+                    "name": "alternate",
+                    "value": "false"
+                  },
+                  "blockImpersonation": {
+                    "description": "",
+                    "name": "blockImpersonation",
+                    "value": "false"
+                  },
+                  "configurable": {
+                    "description": "",
+                    "name": "configurable",
+                    "value": "false"
+                  },
+                  "disableDynamicTitle": {
+                    "description": "",
+                    "name": "disableDynamicTitle",
+                    "value": "true"
+                  },
+                  "disablePortletEvents": {
+                    "description": "",
+                    "name": "disablePortletEvents",
+                    "value": "false"
+                  },
+                  "editable": {
+                    "description": "",
+                    "name": "editable",
+                    "value": "false"
+                  },
+                  "hasAbout": {
+                    "description": "",
+                    "name": "hasAbout",
+                    "value": "false"
+                  },
+                  "hasHelp": {
+                    "description": "",
+                    "name": "hasHelp",
+                    "value": "false"
+                  },
+                  "hideFromDesktop": {
+                    "description": "",
+                    "name": "hideFromDesktop",
+                    "value": "false"
+                  },
+                  "hideFromMobile": {
+                    "description": "",
+                    "name": "hideFromMobile",
+                    "value": "false"
+                  },
+                  "iconUrl": {
+                    "description": "",
+                    "name": "iconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/AidePortailENT.svg"
+                  },
+                  "locale": {
+                    "description": "",
+                    "name": "locale",
+                    "value": "false"
+                  },
+                  "mobileIconUrl": {
+                    "description": "",
+                    "name": "mobileIconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/AidePortailENT.svg"
+                  }
+                },
+                "ratingsCount": 1,
+                "state": "PUBLISHED",
+                "title": "Aide du portail ENT",
+                "typeId": 7
+              },
+              {
+                "averageRating": 0,
+                "description": "Aides et informations r\u00e9gionales pour les CFA                                                                R\u00e9gion Centre-Val de Loire, financi\u00e8re, \u00e9quipements, subventions, CFA",
+                "favorite": false,
+                "fname": "aidesInfosCFA",
+                "id": 115,
+                "keywords": [],
+                "name": "Aides et informations r\u00e9gionales",
+                "parameters": {
+                  "alternate": {
+                    "description": "",
+                    "name": "alternate",
+                    "value": "false"
+                  },
+                  "blockImpersonation": {
+                    "description": "",
+                    "name": "blockImpersonation",
+                    "value": "false"
+                  },
+                  "disableDynamicTitle": {
+                    "description": "",
+                    "name": "disableDynamicTitle",
+                    "value": "true"
+                  },
+                  "editable": {
+                    "description": "",
+                    "name": "editable",
+                    "value": "false"
+                  },
+                  "hasAbout": {
+                    "description": "",
+                    "name": "hasAbout",
+                    "value": "false"
+                  },
+                  "hasHelp": {
+                    "description": "",
+                    "name": "hasHelp",
+                    "value": "false"
+                  },
+                  "hideFromDesktop": {
+                    "description": "",
+                    "name": "hideFromDesktop",
+                    "value": "false"
+                  },
+                  "hideFromMobile": {
+                    "description": "",
+                    "name": "hideFromMobile",
+                    "value": "false"
+                  },
+                  "highlight": {
+                    "description": "",
+                    "name": "highlight",
+                    "value": "false"
+                  },
+                  "iconUrl": {
+                    "description": "",
+                    "name": "iconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/aidesInfosCFA.svg"
+                  },
+                  "locale": {
+                    "description": "",
+                    "name": "locale",
+                    "value": "false"
+                  },
+                  "mobileIconUrl": {
+                    "description": "",
+                    "name": "mobileIconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/aidesInfosCFA.svg"
+                  },
+                  "printable": {
+                    "description": "",
+                    "name": "printable",
+                    "value": "false"
+                  },
+                  "secure": {
+                    "description": "",
+                    "name": "secure",
+                    "value": "false"
+                  },
+                  "showChrome": {
+                    "description": "",
+                    "name": "showChrome",
+                    "value": "true"
+                  }
+                },
+                "ratingsCount": 0,
+                "state": "PUBLISHED",
+                "title": "Aides et informations r\u00e9gionales",
+                "typeId": 7
+              },
+              {
+                "averageRating": 0,
+                "description": "Acc\u00e8s aux ressources du CDI                                                                                  centre de documentation, information, biblioth\u00e8que, documentation, livres, scolaires, emprunter, multi-m\u00e9dia, ressources, num\u00e9riques, e-sidoc",
+                "favorite": false,
+                "fname": "MonCDIPLCourier",
+                "id": 83,
+                "keywords": [],
+                "name": "CDI du coll\u00e8ge",
+                "parameters": {
+                  "alternate": {
+                    "description": "",
+                    "name": "alternate",
+                    "value": "false"
+                  },
+                  "alternativeMaximizedLink": {
+                    "description": "",
+                    "name": "alternativeMaximizedLink",
+                    "value": "/portail/api/ExternalURLStats?fname=ESIDOC&service=https://0379998s.esidoc.fr/home/"
+                  },
+                  "blockImpersonation": {
+                    "description": "",
+                    "name": "blockImpersonation",
+                    "value": "false"
+                  },
+                  "disableDynamicTitle": {
+                    "description": "",
+                    "name": "disableDynamicTitle",
+                    "value": "true"
+                  },
+                  "editable": {
+                    "description": "",
+                    "name": "editable",
+                    "value": "false"
+                  },
+                  "hasAbout": {
+                    "description": "",
+                    "name": "hasAbout",
+                    "value": "false"
+                  },
+                  "hasHelp": {
+                    "description": "",
+                    "name": "hasHelp",
+                    "value": "false"
+                  },
+                  "hideFromDesktop": {
+                    "description": "",
+                    "name": "hideFromDesktop",
+                    "value": "false"
+                  },
+                  "hideFromMobile": {
+                    "description": "",
+                    "name": "hideFromMobile",
+                    "value": "false"
+                  },
+                  "highlight": {
+                    "description": "",
+                    "name": "highlight",
+                    "value": "false"
+                  },
+                  "iconUrl": {
+                    "description": "",
+                    "name": "iconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/MonCDIPLCourier.svg"
+                  },
+                  "mobileIconUrl": {
+                    "description": "",
+                    "name": "mobileIconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/MonCDIPLCourier.svg"
+                  },
+                  "printable": {
+                    "description": "",
+                    "name": "printable",
+                    "value": "false"
+                  },
+                  "showChrome": {
+                    "description": "",
+                    "name": "showChrome",
+                    "value": "true"
+                  }
+                },
+                "ratingsCount": 0,
+                "state": "PUBLISHED",
+                "title": "CDI du coll\u00e8ge",
+                "typeId": 4
+              },
+              {
+                "averageRating": 0,
+                "description": "Messagerie \u00e9lectronique des personnels de l'enseignement agricole                                            courriel, courrier, mail, webmail, \u00e9ducagri, professionnel, poster",
+                "favorite": false,
+                "fname": "CourrielEducagri",
+                "id": 51,
+                "keywords": [],
+                "name": "Courriel \u00c9ducagri",
+                "parameters": {
+                  "alternate": {
+                    "description": "",
+                    "name": "alternate",
+                    "value": "false"
+                  },
+                  "alternativeMaximizedLink": {
+                    "description": "",
+                    "name": "alternativeMaximizedLink",
+                    "value": "/portail/api/ExternalURLStats?fname=CourrielEducagri&service=https://webmail.educagri.fr/"
+                  },
+                  "blockImpersonation": {
+                    "description": "",
+                    "name": "blockImpersonation",
+                    "value": "true"
+                  },
+                  "disableDynamicTitle": {
+                    "description": "",
+                    "name": "disableDynamicTitle",
+                    "value": "true"
+                  },
+                  "editable": {
+                    "description": "",
+                    "name": "editable",
+                    "value": "false"
+                  },
+                  "hasAbout": {
+                    "description": "",
+                    "name": "hasAbout",
+                    "value": "false"
+                  },
+                  "hasHelp": {
+                    "description": "",
+                    "name": "hasHelp",
+                    "value": "false"
+                  },
+                  "hideFromDesktop": {
+                    "description": "",
+                    "name": "hideFromDesktop",
+                    "value": "false"
+                  },
+                  "hideFromMobile": {
+                    "description": "",
+                    "name": "hideFromMobile",
+                    "value": "false"
+                  },
+                  "highlight": {
+                    "description": "",
+                    "name": "highlight",
+                    "value": "false"
+                  },
+                  "iconUrl": {
+                    "description": "",
+                    "name": "iconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/CourrielEducagri.svg"
+                  },
+                  "mobileIconUrl": {
+                    "description": "",
+                    "name": "mobileIconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/CourrielEducagri.svg"
+                  },
+                  "printable": {
+                    "description": "",
+                    "name": "printable",
+                    "value": "false"
+                  },
+                  "showChrome": {
+                    "description": "",
+                    "name": "showChrome",
+                    "value": "true"
+                  }
+                },
+                "ratingsCount": 0,
+                "state": "PUBLISHED",
+                "title": "Courriel \u00c9ducagri",
+                "typeId": 4
+              },
+              {
+                "averageRating": 0,
+                "description": "Messagerie \u00e9lectronique des \u00e9l\u00e8ves                                                                           courrier, courriel, mail, webmail, poster",
+                "favorite": false,
+                "fname": "CourrielEleves",
+                "id": 52,
+                "keywords": [],
+                "name": "Courriel \u00e9l\u00e8ves",
+                "parameters": {
+                  "alternate": {
+                    "description": "",
+                    "name": "alternate",
+                    "value": "false"
+                  },
+                  "blockImpersonation": {
+                    "description": "",
+                    "name": "blockImpersonation",
+                    "value": "true"
+                  },
+                  "editable": {
+                    "description": "",
+                    "name": "editable",
+                    "value": "false"
+                  },
+                  "hasAbout": {
+                    "description": "",
+                    "name": "hasAbout",
+                    "value": "false"
+                  },
+                  "hasHelp": {
+                    "description": "",
+                    "name": "hasHelp",
+                    "value": "false"
+                  },
+                  "hideFromDesktop": {
+                    "description": "",
+                    "name": "hideFromDesktop",
+                    "value": "false"
+                  },
+                  "hideFromMobile": {
+                    "description": "",
+                    "name": "hideFromMobile",
+                    "value": "false"
+                  },
+                  "highlight": {
+                    "description": "",
+                    "name": "highlight",
+                    "value": "false"
+                  },
+                  "iconUrl": {
+                    "description": "",
+                    "name": "iconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/CourrielEleves.svg"
+                  },
+                  "locale": {
+                    "description": "",
+                    "name": "locale",
+                    "value": "false"
+                  },
+                  "mobileIconUrl": {
+                    "description": "",
+                    "name": "mobileIconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/CourrielEleves.svg"
+                  },
+                  "printable": {
+                    "description": "",
+                    "name": "printable",
+                    "value": "false"
+                  },
+                  "secure": {
+                    "description": "",
+                    "name": "secure",
+                    "value": "false"
+                  },
+                  "showChrome": {
+                    "description": "",
+                    "name": "showChrome",
+                    "value": "true"
+                  }
+                },
+                "ratingsCount": 0,
+                "state": "PUBLISHED",
+                "title": "Mon courriel",
+                "typeId": 6
+              },
+              {
+                "averageRating": 0,
+                "description": "Les derni\u00e8res actualit\u00e9s propos\u00e9es par l'\u00e9tablissement                                                       lyc\u00e9e, coll\u00e8ge, CFA, ITS, nouvelles, annonces",
+                "favorite": false,
+                "fname": "ResumeActualitesEtab",
+                "id": 94,
+                "keywords": [],
+                "name": "Derni\u00e8res actualit\u00e9s de l'\u00e9tablissement",
+                "parameters": {
+                  "alternate": {
+                    "description": "",
+                    "name": "alternate",
+                    "value": "false"
+                  },
+                  "blockImpersonation": {
+                    "description": "",
+                    "name": "blockImpersonation",
+                    "value": "false"
+                  },
+                  "disableDynamicTitle": {
+                    "description": "",
+                    "name": "disableDynamicTitle",
+                    "value": "true"
+                  },
+                  "editable": {
+                    "description": "",
+                    "name": "editable",
+                    "value": "false"
+                  },
+                  "hasAbout": {
+                    "description": "",
+                    "name": "hasAbout",
+                    "value": "false"
+                  },
+                  "hasHelp": {
+                    "description": "",
+                    "name": "hasHelp",
+                    "value": "false"
+                  },
+                  "hideFromDesktop": {
+                    "description": "",
+                    "name": "hideFromDesktop",
+                    "value": "false"
+                  },
+                  "hideFromMobile": {
+                    "description": "",
+                    "name": "hideFromMobile",
+                    "value": "false"
+                  },
+                  "highlight": {
+                    "description": "",
+                    "name": "highlight",
+                    "value": "false"
+                  },
+                  "iconUrl": {
+                    "description": "",
+                    "name": "iconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/ResumeActualitesEtab.svg"
+                  },
+                  "locale": {
+                    "description": "",
+                    "name": "locale",
+                    "value": "false"
+                  },
+                  "mobileIconUrl": {
+                    "description": "",
+                    "name": "mobileIconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/ResumeActualitesEtab.svg"
+                  },
+                  "printable": {
+                    "description": "",
+                    "name": "printable",
+                    "value": "false"
+                  },
+                  "secure": {
+                    "description": "",
+                    "name": "secure",
+                    "value": "false"
+                  },
+                  "showChrome": {
+                    "description": "",
+                    "name": "showChrome",
+                    "value": "true"
+                  }
+                },
+                "ratingsCount": 1,
+                "state": "PUBLISHED",
+                "title": "Derni\u00e8res actualit\u00e9s de l'\u00e9tablissement",
+                "typeId": 7
+              },
+              {
+                "averageRating": 0,
+                "description": "Les derni\u00e8res actualit\u00e9s en R\u00e9gion Centre-Val de Loire                                                       nouvelles, annonces",
+                "favorite": false,
+                "fname": "ResumeActualitesRegion",
+                "id": 95,
+                "keywords": [],
+                "name": "Derni\u00e8res actualit\u00e9s en R\u00e9gion",
+                "parameters": {
+                  "alternate": {
+                    "description": "",
+                    "name": "alternate",
+                    "value": "false"
+                  },
+                  "blockImpersonation": {
+                    "description": "",
+                    "name": "blockImpersonation",
+                    "value": "false"
+                  },
+                  "disableDynamicTitle": {
+                    "description": "",
+                    "name": "disableDynamicTitle",
+                    "value": "true"
+                  },
+                  "editable": {
+                    "description": "",
+                    "name": "editable",
+                    "value": "false"
+                  },
+                  "hasAbout": {
+                    "description": "",
+                    "name": "hasAbout",
+                    "value": "false"
+                  },
+                  "hasHelp": {
+                    "description": "",
+                    "name": "hasHelp",
+                    "value": "false"
+                  },
+                  "hideFromDesktop": {
+                    "description": "",
+                    "name": "hideFromDesktop",
+                    "value": "false"
+                  },
+                  "hideFromMobile": {
+                    "description": "",
+                    "name": "hideFromMobile",
+                    "value": "false"
+                  },
+                  "highlight": {
+                    "description": "",
+                    "name": "highlight",
+                    "value": "false"
+                  },
+                  "iconUrl": {
+                    "description": "",
+                    "name": "iconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/ResumeActualitesRegion.svg"
+                  },
+                  "locale": {
+                    "description": "",
+                    "name": "locale",
+                    "value": "false"
+                  },
+                  "mobileIconUrl": {
+                    "description": "",
+                    "name": "mobileIconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/ResumeActualitesRegion.svg"
+                  },
+                  "printable": {
+                    "description": "",
+                    "name": "printable",
+                    "value": "false"
+                  },
+                  "secure": {
+                    "description": "",
+                    "name": "secure",
+                    "value": "false"
+                  },
+                  "showChrome": {
+                    "description": "",
+                    "name": "showChrome",
+                    "value": "true"
+                  }
+                },
+                "ratingsCount": 0,
+                "state": "PUBLISHED",
+                "title": "Derni\u00e8res actualit\u00e9s en R\u00e9gion",
+                "typeId": 7
+              },
+              {
+                "averageRating": 0,
+                "description": "Derni\u00e8res actualit\u00e9s en Touraine, mon d\u00e9partement                                                            Indre-et-Loire, nouvelles, annonces",
+                "favorite": false,
+                "fname": "ResumeActualitesCD37",
+                "id": 93,
+                "keywords": [],
+                "name": "Derni\u00e8res actualit\u00e9s en Touraine",
+                "parameters": {
+                  "alternate": {
+                    "description": "",
+                    "name": "alternate",
+                    "value": "false"
+                  },
+                  "blockImpersonation": {
+                    "description": "",
+                    "name": "blockImpersonation",
+                    "value": "false"
+                  },
+                  "disableDynamicTitle": {
+                    "description": "",
+                    "name": "disableDynamicTitle",
+                    "value": "true"
+                  },
+                  "editable": {
+                    "description": "",
+                    "name": "editable",
+                    "value": "false"
+                  },
+                  "hasAbout": {
+                    "description": "",
+                    "name": "hasAbout",
+                    "value": "false"
+                  },
+                  "hasHelp": {
+                    "description": "",
+                    "name": "hasHelp",
+                    "value": "false"
+                  },
+                  "hideFromDesktop": {
+                    "description": "",
+                    "name": "hideFromDesktop",
+                    "value": "false"
+                  },
+                  "hideFromMobile": {
+                    "description": "",
+                    "name": "hideFromMobile",
+                    "value": "false"
+                  },
+                  "highlight": {
+                    "description": "",
+                    "name": "highlight",
+                    "value": "false"
+                  },
+                  "iconUrl": {
+                    "description": "",
+                    "name": "iconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/ResumeActualitesCD37.svg"
+                  },
+                  "locale": {
+                    "description": "",
+                    "name": "locale",
+                    "value": "false"
+                  },
+                  "mobileIconUrl": {
+                    "description": "",
+                    "name": "mobileIconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/ResumeActualitesCD37.svg"
+                  },
+                  "printable": {
+                    "description": "",
+                    "name": "printable",
+                    "value": "false"
+                  },
+                  "secure": {
+                    "description": "",
+                    "name": "secure",
+                    "value": "false"
+                  },
+                  "showChrome": {
+                    "description": "",
+                    "name": "showChrome",
+                    "value": "false"
+                  }
+                },
+                "ratingsCount": 0,
+                "state": "PUBLISHED",
+                "title": "Derni\u00e8res actualit\u00e9s en Touraine",
+                "typeId": 7
+              },
+              {
+                "averageRating": 0,
+                "description": "Les derni\u00e8res informations du GIP RECIA pour les administrateurs                                             actualit\u00e9s, ENT, GSI, GIP RECIA, incidents, nouvelles, annonces",
+                "favorite": false,
+                "fname": "ResumeInfosENT",
+                "id": 96,
+                "keywords": [],
+                "name": "Derni\u00e8res informations administrateurs",
+                "parameters": {
+                  "alternate": {
+                    "description": "",
+                    "name": "alternate",
+                    "value": "false"
+                  },
+                  "blockImpersonation": {
+                    "description": "",
+                    "name": "blockImpersonation",
+                    "value": "false"
+                  },
+                  "disableDynamicTitle": {
+                    "description": "",
+                    "name": "disableDynamicTitle",
+                    "value": "true"
+                  },
+                  "editable": {
+                    "description": "",
+                    "name": "editable",
+                    "value": "false"
+                  },
+                  "hasAbout": {
+                    "description": "",
+                    "name": "hasAbout",
+                    "value": "false"
+                  },
+                  "hasHelp": {
+                    "description": "",
+                    "name": "hasHelp",
+                    "value": "false"
+                  },
+                  "hideFromDesktop": {
+                    "description": "",
+                    "name": "hideFromDesktop",
+                    "value": "false"
+                  },
+                  "hideFromMobile": {
+                    "description": "",
+                    "name": "hideFromMobile",
+                    "value": "false"
+                  },
+                  "highlight": {
+                    "description": "",
+                    "name": "highlight",
+                    "value": "false"
+                  },
+                  "iconUrl": {
+                    "description": "",
+                    "name": "iconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/ResumeInfosENT"
+                  },
+                  "locale": {
+                    "description": "",
+                    "name": "locale",
+                    "value": "false"
+                  },
+                  "mobileIconUrl": {
+                    "description": "",
+                    "name": "mobileIconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/ResumeInfosENT"
+                  },
+                  "printable": {
+                    "description": "",
+                    "name": "printable",
+                    "value": "false"
+                  },
+                  "secure": {
+                    "description": "",
+                    "name": "secure",
+                    "value": "false"
+                  },
+                  "showChrome": {
+                    "description": "",
+                    "name": "showChrome",
+                    "value": "true"
+                  }
+                },
+                "ratingsCount": 1,
+                "state": "PUBLISHED",
+                "title": "Derni\u00e8res informations administrateurs",
+                "typeId": 7
+              },
+              {
+                "averageRating": 0,
+                "description": "Description du projet NetO'centre dans les lyc\u00e9es                                                            ENT, R\u00e9gion Centre-Val de Loire, acad\u00e9mie, Orl\u00e9ans, Tours, pr\u00e9sentation, information",
+                "favorite": false,
+                "fname": "accueil-lycees",
+                "id": 114,
+                "keywords": [],
+                "name": "Description NetO'centre",
+                "parameters": {
+                  "alternate": {
+                    "description": "",
+                    "name": "alternate",
+                    "value": "false"
+                  },
+                  "blockImpersonation": {
+                    "description": "",
+                    "name": "blockImpersonation",
+                    "value": "false"
+                  },
+                  "disableDynamicTitle": {
+                    "description": "",
+                    "name": "disableDynamicTitle",
+                    "value": "true"
+                  },
+                  "editable": {
+                    "description": "",
+                    "name": "editable",
+                    "value": "false"
+                  },
+                  "hasAbout": {
+                    "description": "",
+                    "name": "hasAbout",
+                    "value": "false"
+                  },
+                  "hasHelp": {
+                    "description": "",
+                    "name": "hasHelp",
+                    "value": "false"
+                  },
+                  "hideFromDesktop": {
+                    "description": "",
+                    "name": "hideFromDesktop",
+                    "value": "false"
+                  },
+                  "hideFromMobile": {
+                    "description": "",
+                    "name": "hideFromMobile",
+                    "value": "false"
+                  },
+                  "highlight": {
+                    "description": "",
+                    "name": "highlight",
+                    "value": "false"
+                  },
+                  "iconUrl": {
+                    "description": "",
+                    "name": "iconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/accueil-lycees.svg"
+                  },
+                  "locale": {
+                    "description": "",
+                    "name": "locale",
+                    "value": "false"
+                  },
+                  "mobileIconUrl": {
+                    "description": "",
+                    "name": "mobileIconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/accueil-lycees.svg"
+                  },
+                  "printable": {
+                    "description": "",
+                    "name": "printable",
+                    "value": "false"
+                  },
+                  "secure": {
+                    "description": "",
+                    "name": "secure",
+                    "value": "false"
+                  },
+                  "showChrome": {
+                    "description": "",
+                    "name": "showChrome",
+                    "value": "true"
+                  }
+                },
+                "ratingsCount": 0,
+                "state": "PUBLISHED",
+                "title": "Description de NetO'centre",
+                "typeId": 4
+              },
+              {
+                "averageRating": 0,
+                "description": "Description du projet Touraine-eschool                                                                       ENT, D\u00e9partement, Touraine, Indre-et-Loire, acad\u00e9mie, Orl\u00e9ans, Tours, pr\u00e9sentation, information",
+                "favorite": false,
+                "fname": "accueil-clg37",
+                "id": 113,
+                "keywords": [],
+                "name": "Description Touraine E-School",
+                "parameters": {
+                  "alternate": {
+                    "description": "",
+                    "name": "alternate",
+                    "value": "false"
+                  },
+                  "blockImpersonation": {
+                    "description": "",
+                    "name": "blockImpersonation",
+                    "value": "false"
+                  },
+                  "disableDynamicTitle": {
+                    "description": "",
+                    "name": "disableDynamicTitle",
+                    "value": "true"
+                  },
+                  "editable": {
+                    "description": "",
+                    "name": "editable",
+                    "value": "false"
+                  },
+                  "hasAbout": {
+                    "description": "",
+                    "name": "hasAbout",
+                    "value": "false"
+                  },
+                  "hasHelp": {
+                    "description": "",
+                    "name": "hasHelp",
+                    "value": "false"
+                  },
+                  "hideFromDesktop": {
+                    "description": "",
+                    "name": "hideFromDesktop",
+                    "value": "false"
+                  },
+                  "hideFromMobile": {
+                    "description": "",
+                    "name": "hideFromMobile",
+                    "value": "false"
+                  },
+                  "highlight": {
+                    "description": "",
+                    "name": "highlight",
+                    "value": "false"
+                  },
+                  "iconUrl": {
+                    "description": "",
+                    "name": "iconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/accueil-clg37.svg"
+                  },
+                  "locale": {
+                    "description": "",
+                    "name": "locale",
+                    "value": "false"
+                  },
+                  "mobileIconUrl": {
+                    "description": "",
+                    "name": "mobileIconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/accueil-clg37.svg"
+                  },
+                  "printable": {
+                    "description": "",
+                    "name": "printable",
+                    "value": "false"
+                  },
+                  "secure": {
+                    "description": "",
+                    "name": "secure",
+                    "value": "false"
+                  },
+                  "showChrome": {
+                    "description": "",
+                    "name": "showChrome",
+                    "value": "true"
+                  }
+                },
+                "ratingsCount": 0,
+                "state": "PUBLISHED",
+                "title": "Description de Touraine E-School",
+                "typeId": 4
+              },
+              {
+                "averageRating": 0,
+                "description": "Description du projet NetO'centre dans les CFA                                                               ENT, R\u00e9gion Centre-Val de Loire, pr\u00e9sentation, information",
+                "favorite": false,
+                "fname": "accueil-cfa",
+                "id": 112,
+                "keywords": [],
+                "name": "Description de NetO'centre",
+                "parameters": {
+                  "alternate": {
+                    "description": "",
+                    "name": "alternate",
+                    "value": "false"
+                  },
+                  "blockImpersonation": {
+                    "description": "",
+                    "name": "blockImpersonation",
+                    "value": "false"
+                  },
+                  "disableDynamicTitle": {
+                    "description": "",
+                    "name": "disableDynamicTitle",
+                    "value": "true"
+                  },
+                  "editable": {
+                    "description": "",
+                    "name": "editable",
+                    "value": "false"
+                  },
+                  "hasAbout": {
+                    "description": "",
+                    "name": "hasAbout",
+                    "value": "false"
+                  },
+                  "hasHelp": {
+                    "description": "",
+                    "name": "hasHelp",
+                    "value": "false"
+                  },
+                  "hideFromDesktop": {
+                    "description": "",
+                    "name": "hideFromDesktop",
+                    "value": "false"
+                  },
+                  "hideFromMobile": {
+                    "description": "",
+                    "name": "hideFromMobile",
+                    "value": "false"
+                  },
+                  "highlight": {
+                    "description": "",
+                    "name": "highlight",
+                    "value": "false"
+                  },
+                  "iconUrl": {
+                    "description": "",
+                    "name": "iconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/accueil-cfa.svg"
+                  },
+                  "locale": {
+                    "description": "",
+                    "name": "locale",
+                    "value": "false"
+                  },
+                  "mobileIconUrl": {
+                    "description": "",
+                    "name": "mobileIconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/accueil-cfa.svg"
+                  },
+                  "printable": {
+                    "description": "",
+                    "name": "printable",
+                    "value": "false"
+                  },
+                  "secure": {
+                    "description": "",
+                    "name": "secure",
+                    "value": "false"
+                  },
+                  "showChrome": {
+                    "description": "",
+                    "name": "showChrome",
+                    "value": "true"
+                  }
+                },
+                "ratingsCount": 0,
+                "state": "PUBLISHED",
+                "title": "Description de NetO'centre",
+                "typeId": 4
+              },
+              {
+                "averageRating": 0,
+                "description": "Les documents mis \u00e0 disposition par l'\u00e9tablissement                                                            lyc\u00e9e, coll\u00e8ge, CFA, ITS, formulaires, notes, compte-rendus, notices, r\u00e9glements",
+                "favorite": false,
+                "fname": "DocumentsEtab",
+                "id": 55,
+                "keywords": [],
+                "name": "Documents de l'\u00e9tablissement",
+                "parameters": {
+                  "alternate": {
+                    "description": "",
+                    "name": "alternate",
+                    "value": "false"
+                  },
+                  "blockImpersonation": {
+                    "description": "",
+                    "name": "blockImpersonation",
+                    "value": "false"
+                  },
+                  "disableDynamicTitle": {
+                    "description": "",
+                    "name": "disableDynamicTitle",
+                    "value": "true"
+                  },
+                  "editable": {
+                    "description": "",
+                    "name": "editable",
+                    "value": "false"
+                  },
+                  "hasAbout": {
+                    "description": "",
+                    "name": "hasAbout",
+                    "value": "false"
+                  },
+                  "hasHelp": {
+                    "description": "",
+                    "name": "hasHelp",
+                    "value": "false"
+                  },
+                  "hideFromDesktop": {
+                    "description": "",
+                    "name": "hideFromDesktop",
+                    "value": "false"
+                  },
+                  "hideFromMobile": {
+                    "description": "",
+                    "name": "hideFromMobile",
+                    "value": "false"
+                  },
+                  "highlight": {
+                    "description": "",
+                    "name": "highlight",
+                    "value": "false"
+                  },
+                  "iconUrl": {
+                    "description": "",
+                    "name": "iconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/DocumentsEtab.svg"
+                  },
+                  "locale": {
+                    "description": "",
+                    "name": "locale",
+                    "value": "false"
+                  },
+                  "mobileIconUrl": {
+                    "description": "",
+                    "name": "mobileIconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/DocumentsEtab.svg"
+                  },
+                  "printable": {
+                    "description": "",
+                    "name": "printable",
+                    "value": "false"
+                  },
+                  "secure": {
+                    "description": "",
+                    "name": "secure",
+                    "value": "false"
+                  },
+                  "showChrome": {
+                    "description": "",
+                    "name": "showChrome",
+                    "value": "true"
+                  }
+                },
+                "ratingsCount": 0,
+                "state": "PUBLISHED",
+                "title": "Documents de l'\u00e9tablissement",
+                "typeId": 7
+              },
+              {
+                "averageRating": 0,
+                "description": "Ressources documentaires (PMB)                                                                               centre de documentation, information, biblioth\u00e8que, documentation, livres, scolaires, emprunt, emprunter, multi-m\u00e9dia, ressources, num\u00e9riques",
+                "favorite": false,
+                "fname": "PMB",
+                "id": 87,
+                "keywords": [],
+                "name": "Gestion documentaire",
+                "parameters": {
+                  "alternate": {
+                    "description": "",
+                    "name": "alternate",
+                    "value": "false"
+                  },
+                  "blockImpersonation": {
+                    "description": "",
+                    "name": "blockImpersonation",
+                    "value": "true"
+                  },
+                  "editable": {
+                    "description": "",
+                    "name": "editable",
+                    "value": "false"
+                  },
+                  "hasAbout": {
+                    "description": "",
+                    "name": "hasAbout",
+                    "value": "false"
+                  },
+                  "hasHelp": {
+                    "description": "",
+                    "name": "hasHelp",
+                    "value": "false"
+                  },
+                  "hideFromDesktop": {
+                    "description": "",
+                    "name": "hideFromDesktop",
+                    "value": "false"
+                  },
+                  "hideFromMobile": {
+                    "description": "",
+                    "name": "hideFromMobile",
+                    "value": "false"
+                  },
+                  "highlight": {
+                    "description": "",
+                    "name": "highlight",
+                    "value": "false"
+                  },
+                  "iconUrl": {
+                    "description": "",
+                    "name": "iconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/PMB.svg"
+                  },
+                  "locale": {
+                    "description": "",
+                    "name": "locale",
+                    "value": "false"
+                  },
+                  "mobileIconUrl": {
+                    "description": "",
+                    "name": "mobileIconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/PMB.svg"
+                  },
+                  "printable": {
+                    "description": "",
+                    "name": "printable",
+                    "value": "false"
+                  },
+                  "secure": {
+                    "description": "",
+                    "name": "secure",
+                    "value": "false"
+                  },
+                  "showChrome": {
+                    "description": "",
+                    "name": "showChrome",
+                    "value": "true"
+                  }
+                },
+                "ratingsCount": 0,
+                "state": "PUBLISHED",
+                "title": "Gestion documentaire",
+                "typeId": 6
+              },
+              {
+                "averageRating": 0,
+                "description": "Actualit\u00e9s du GIP RECIA \u00e0 destination des admnistrateurs ENT                                                 actualit\u00e9s, ENT, GSI, GIP RECIA, incidents, nouvelles, annonces",
+                "favorite": false,
+                "fname": "AnnoncesRECIA",
+                "id": 47,
+                "keywords": [],
+                "name": "Information administrateurs",
+                "parameters": {
+                  "alternate": {
+                    "description": "",
+                    "name": "alternate",
+                    "value": "false"
+                  },
+                  "blockImpersonation": {
+                    "description": "",
+                    "name": "blockImpersonation",
+                    "value": "false"
+                  },
+                  "disableDynamicTitle": {
+                    "description": "",
+                    "name": "disableDynamicTitle",
+                    "value": "true"
+                  },
+                  "editable": {
+                    "description": "",
+                    "name": "editable",
+                    "value": "false"
+                  },
+                  "hasAbout": {
+                    "description": "",
+                    "name": "hasAbout",
+                    "value": "false"
+                  },
+                  "hasHelp": {
+                    "description": "",
+                    "name": "hasHelp",
+                    "value": "false"
+                  },
+                  "hideFromDesktop": {
+                    "description": "",
+                    "name": "hideFromDesktop",
+                    "value": "false"
+                  },
+                  "hideFromMobile": {
+                    "description": "",
+                    "name": "hideFromMobile",
+                    "value": "false"
+                  },
+                  "highlight": {
+                    "description": "",
+                    "name": "highlight",
+                    "value": "false"
+                  },
+                  "iconUrl": {
+                    "description": "",
+                    "name": "iconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/AnnoncesRECIA.svg"
+                  },
+                  "locale": {
+                    "description": "",
+                    "name": "locale",
+                    "value": "false"
+                  },
+                  "mobileIconUrl": {
+                    "description": "",
+                    "name": "mobileIconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/AnnoncesRECIA.svg"
+                  },
+                  "printable": {
+                    "description": "",
+                    "name": "printable",
+                    "value": "false"
+                  },
+                  "secure": {
+                    "description": "",
+                    "name": "secure",
+                    "value": "false"
+                  },
+                  "showChrome": {
+                    "description": "",
+                    "name": "showChrome",
+                    "value": "true"
+                  }
+                },
+                "ratingsCount": 0,
+                "state": "PUBLISHED",
+                "title": "Information administrateurs",
+                "typeId": 7
+              },
+              {
+                "averageRating": 0,
+                "description": "L'\u00e9ducation en Touraine, les actions du Conseil D\u00e9partemental d\u2019Indre-et-Loire                               informations, actions scolaires, actions \u00e9ducatives, actions sociales, \u00e9l\u00e8ves, parents",
+                "favorite": false,
+                "fname": "EducationTouraine",
+                "id": 60,
+                "keywords": [],
+                "name": "L'\u00e9ducation en Touraine",
+                "parameters": {
+                  "alternate": {
+                    "description": "",
+                    "name": "alternate",
+                    "value": "false"
+                  },
+                  "blockImpersonation": {
+                    "description": "",
+                    "name": "blockImpersonation",
+                    "value": "false"
+                  },
+                  "disableDynamicTitle": {
+                    "description": "",
+                    "name": "disableDynamicTitle",
+                    "value": "true"
+                  },
+                  "editable": {
+                    "description": "",
+                    "name": "editable",
+                    "value": "false"
+                  },
+                  "hasAbout": {
+                    "description": "",
+                    "name": "hasAbout",
+                    "value": "false"
+                  },
+                  "hasHelp": {
+                    "description": "",
+                    "name": "hasHelp",
+                    "value": "false"
+                  },
+                  "hideFromDesktop": {
+                    "description": "",
+                    "name": "hideFromDesktop",
+                    "value": "false"
+                  },
+                  "hideFromMobile": {
+                    "description": "",
+                    "name": "hideFromMobile",
+                    "value": "false"
+                  },
+                  "highlight": {
+                    "description": "",
+                    "name": "highlight",
+                    "value": "false"
+                  },
+                  "iconUrl": {
+                    "description": "",
+                    "name": "iconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/EducationTouraine.svg"
+                  },
+                  "mobileIconUrl": {
+                    "description": "",
+                    "name": "mobileIconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/EducationTouraine.svg"
+                  },
+                  "printable": {
+                    "description": "",
+                    "name": "printable",
+                    "value": "false"
+                  },
+                  "showChrome": {
+                    "description": "",
+                    "name": "showChrome",
+                    "value": "true"
+                  }
+                },
+                "ratingsCount": 0,
+                "state": "PUBLISHED",
+                "title": "L'\u00e9ducation en Touraine",
+                "typeId": 4
+              },
+              {
+                "averageRating": 0,
+                "description": "Acc\u00e8s aux ressources des CDI du Lyc\u00e9e Th\u00e9r\u00e8se Planiol                                                        centre de documentation, information, biblioth\u00e8que, documentation, livres, scolaires, emprunter, multi-m\u00e9dia, ressources, num\u00e9riques, e-sidoc",
+                "favorite": false,
+                "fname": "CDITheresePlaniol",
+                "id": 48,
+                "keywords": [],
+                "name": "Les CDI Th\u00e9r\u00e8se Planiol",
+                "parameters": {
+                  "alternate": {
+                    "description": "",
+                    "name": "alternate",
+                    "value": "false"
+                  },
+                  "blockImpersonation": {
+                    "description": "",
+                    "name": "blockImpersonation",
+                    "value": "false"
+                  },
+                  "disableDynamicTitle": {
+                    "description": "",
+                    "name": "disableDynamicTitle",
+                    "value": "true"
+                  },
+                  "editable": {
+                    "description": "",
+                    "name": "editable",
+                    "value": "false"
+                  },
+                  "hasAbout": {
+                    "description": "",
+                    "name": "hasAbout",
+                    "value": "false"
+                  },
+                  "hasHelp": {
+                    "description": "",
+                    "name": "hasHelp",
+                    "value": "false"
+                  },
+                  "hideFromDesktop": {
+                    "description": "",
+                    "name": "hideFromDesktop",
+                    "value": "false"
+                  },
+                  "hideFromMobile": {
+                    "description": "",
+                    "name": "hideFromMobile",
+                    "value": "false"
+                  },
+                  "highlight": {
+                    "description": "",
+                    "name": "highlight",
+                    "value": "false"
+                  },
+                  "iconUrl": {
+                    "description": "",
+                    "name": "iconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/CDITheresePlaniol.svg"
+                  },
+                  "mobileIconUrl": {
+                    "description": "",
+                    "name": "mobileIconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/CDITheresePlaniol.svg"
+                  },
+                  "printable": {
+                    "description": "",
+                    "name": "printable",
+                    "value": "false"
+                  },
+                  "showChrome": {
+                    "description": "",
+                    "name": "showChrome",
+                    "value": "true"
+                  }
+                },
+                "ratingsCount": 0,
+                "state": "PUBLISHED",
+                "title": "Les CDI Th\u00e9r\u00e8se Planiol",
+                "typeId": 4
+              },
+              {
+                "averageRating": 0,
+                "description": "Lettre d'information pour les utilisateurs de l'ENT                                                          NetO'Centre, R\u00e9gion Centre-Val de Loire, nouveaut\u00e9s, portail, applications, services",
+                "favorite": false,
+                "fname": "LettreActualites",
+                "id": 77,
+                "keywords": [],
+                "name": "Lettre d'actualit\u00e9s",
+                "parameters": {
+                  "alternate": {
+                    "description": "",
+                    "name": "alternate",
+                    "value": "false"
+                  },
+                  "blockImpersonation": {
+                    "description": "",
+                    "name": "blockImpersonation",
+                    "value": "false"
+                  },
+                  "disableDynamicTitle": {
+                    "description": "",
+                    "name": "disableDynamicTitle",
+                    "value": "true"
+                  },
+                  "editable": {
+                    "description": "",
+                    "name": "editable",
+                    "value": "false"
+                  },
+                  "hasAbout": {
+                    "description": "",
+                    "name": "hasAbout",
+                    "value": "false"
+                  },
+                  "hasHelp": {
+                    "description": "",
+                    "name": "hasHelp",
+                    "value": "false"
+                  },
+                  "hideFromDesktop": {
+                    "description": "",
+                    "name": "hideFromDesktop",
+                    "value": "false"
+                  },
+                  "hideFromMobile": {
+                    "description": "",
+                    "name": "hideFromMobile",
+                    "value": "false"
+                  },
+                  "highlight": {
+                    "description": "",
+                    "name": "highlight",
+                    "value": "false"
+                  },
+                  "iconUrl": {
+                    "description": "",
+                    "name": "iconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/LettreActualites.svg"
+                  },
+                  "mobileIconUrl": {
+                    "description": "",
+                    "name": "mobileIconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/LettreActualites.svg"
+                  },
+                  "printable": {
+                    "description": "",
+                    "name": "printable",
+                    "value": "false"
+                  },
+                  "showChrome": {
+                    "description": "",
+                    "name": "showChrome",
+                    "value": "true"
+                  }
+                },
+                "ratingsCount": 0,
+                "state": "PUBLISHED",
+                "title": "Lettre d'actualit\u00e9s",
+                "typeId": 4
+              },
+              {
+                "averageRating": 0,
+                "description": "Les listes de diffusion de l'\u00e9tablissement                                                                     courriel, courrier, \u00e9lectronique, mail, diffuser, poster",
+                "favorite": false,
+                "fname": "ListesDiffusion",
+                "id": 80,
+                "keywords": [],
+                "name": "Listes de diffusion",
+                "parameters": {
+                  "alternate": {
+                    "description": "",
+                    "name": "alternate",
+                    "value": "false"
+                  },
+                  "blockImpersonation": {
+                    "description": "",
+                    "name": "blockImpersonation",
+                    "value": "false"
+                  },
+                  "disableDynamicTitle": {
+                    "description": "",
+                    "name": "disableDynamicTitle",
+                    "value": "true"
+                  },
+                  "editable": {
+                    "description": "",
+                    "name": "editable",
+                    "value": "false"
+                  },
+                  "hasAbout": {
+                    "description": "",
+                    "name": "hasAbout",
+                    "value": "false"
+                  },
+                  "hasHelp": {
+                    "description": "",
+                    "name": "hasHelp",
+                    "value": "false"
+                  },
+                  "hideFromDesktop": {
+                    "description": "",
+                    "name": "hideFromDesktop",
+                    "value": "false"
+                  },
+                  "hideFromMobile": {
+                    "description": "",
+                    "name": "hideFromMobile",
+                    "value": "false"
+                  },
+                  "highlight": {
+                    "description": "",
+                    "name": "highlight",
+                    "value": "false"
+                  },
+                  "iconUrl": {
+                    "description": "",
+                    "name": "iconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/ListesDiffusion.svg"
+                  },
+                  "locale": {
+                    "description": "",
+                    "name": "locale",
+                    "value": "false"
+                  },
+                  "mobileIconUrl": {
+                    "description": "",
+                    "name": "mobileIconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/ListesDiffusion.svg"
+                  },
+                  "printable": {
+                    "description": "",
+                    "name": "printable",
+                    "value": "false"
+                  },
+                  "secure": {
+                    "description": "",
+                    "name": "secure",
+                    "value": "false"
+                  },
+                  "showChrome": {
+                    "description": "",
+                    "name": "showChrome",
+                    "value": "true"
+                  }
+                },
+                "ratingsCount": 0,
+                "state": "PUBLISHED",
+                "title": "Listes de diffusion",
+                "typeId": 7
+              },
+              {
+                "averageRating": 0,
+                "description": "Informations sur le projet de maintenance informatique dans les lyc\u00e9es                                       administration, administrateur, itop, CSL, Correspondant Support Local, assistance, ordinateurs, PC, logiciels",
+                "favorite": false,
+                "fname": "MILycees",
+                "id": 136,
+                "keywords": [],
+                "name": "Maintenance informatique des lyc\u00e9es",
+                "parameters": {
+                  "alternate": {
+                    "description": "",
+                    "name": "alternate",
+                    "value": "false"
+                  },
+                  "blockImpersonation": {
+                    "description": "",
+                    "name": "blockImpersonation",
+                    "value": "true"
+                  },
+                  "chromeStyle": {
+                    "description": "",
+                    "name": "chromeStyle",
+                    "value": "default"
+                  },
+                  "configurable": {
+                    "description": "",
+                    "name": "configurable",
+                    "value": "false"
+                  },
+                  "disableDynamicTitle": {
+                    "description": "",
+                    "name": "disableDynamicTitle",
+                    "value": "true"
+                  },
+                  "disablePortletEvents": {
+                    "description": "",
+                    "name": "disablePortletEvents",
+                    "value": "false"
+                  },
+                  "editable": {
+                    "description": "",
+                    "name": "editable",
+                    "value": "false"
+                  },
+                  "hasAbout": {
+                    "description": "",
+                    "name": "hasAbout",
+                    "value": "false"
+                  },
+                  "hasHelp": {
+                    "description": "",
+                    "name": "hasHelp",
+                    "value": "false"
+                  },
+                  "hideFromDesktop": {
+                    "description": "",
+                    "name": "hideFromDesktop",
+                    "value": "false"
+                  },
+                  "hideFromMobile": {
+                    "description": "",
+                    "name": "hideFromMobile",
+                    "value": "false"
+                  },
+                  "highlight": {
+                    "description": "",
+                    "name": "highlight",
+                    "value": "false"
+                  },
+                  "iconUrl": {
+                    "description": "",
+                    "name": "iconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/MILycees.svg"
+                  },
+                  "mobileIconUrl": {
+                    "description": "",
+                    "name": "mobileIconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/MILycees.svg"
+                  },
+                  "printable": {
+                    "description": "",
+                    "name": "printable",
+                    "value": "false"
+                  },
+                  "showChrome": {
+                    "description": "",
+                    "name": "showChrome",
+                    "value": "true"
+                  }
+                },
+                "ratingsCount": 0,
+                "state": "PUBLISHED",
+                "title": "Maintenance informatique des lyc\u00e9es",
+                "typeId": 4
+              },
+              {
+                "averageRating": 0,
+                "description": "Messagerie \u00e9lectronique des personnels de l'\u00e9ducation nationale                                                courriel, courrier, mail, webmail, acad\u00e9mique, acad\u00e9mie, professionnel, Orl\u00e9ans, Tours, rectorat",
+                "favorite": false,
+                "fname": "CourrielAcademique",
+                "id": 50,
+                "keywords": [],
+                "name": "Messagerie acad\u00e9mique",
+                "parameters": {
+                  "alternate": {
+                    "description": "",
+                    "name": "alternate",
+                    "value": "false"
+                  },
+                  "alternativeMaximizedLink": {
+                    "description": "",
+                    "name": "alternativeMaximizedLink",
+                    "value": "/portail/api/ExternalURLStats?fname=CourrielAcademique&service=https://extraent.ac-orleans-tours.fr/iwc_frame/"
+                  },
+                  "blockImpersonation": {
+                    "description": "",
+                    "name": "blockImpersonation",
+                    "value": "true"
+                  },
+                  "disableDynamicTitle": {
+                    "description": "",
+                    "name": "disableDynamicTitle",
+                    "value": "true"
+                  },
+                  "editable": {
+                    "description": "",
+                    "name": "editable",
+                    "value": "false"
+                  },
+                  "hasAbout": {
+                    "description": "",
+                    "name": "hasAbout",
+                    "value": "false"
+                  },
+                  "hasHelp": {
+                    "description": "",
+                    "name": "hasHelp",
+                    "value": "false"
+                  },
+                  "hideFromDesktop": {
+                    "description": "",
+                    "name": "hideFromDesktop",
+                    "value": "false"
+                  },
+                  "hideFromMobile": {
+                    "description": "",
+                    "name": "hideFromMobile",
+                    "value": "false"
+                  },
+                  "highlight": {
+                    "description": "",
+                    "name": "highlight",
+                    "value": "false"
+                  },
+                  "iconUrl": {
+                    "description": "",
+                    "name": "iconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/CourrielAcademique.svg"
+                  },
+                  "mobileIconUrl": {
+                    "description": "",
+                    "name": "mobileIconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/CourrielAcademique.svg"
+                  },
+                  "printable": {
+                    "description": "",
+                    "name": "printable",
+                    "value": "false"
+                  },
+                  "showChrome": {
+                    "description": "",
+                    "name": "showChrome",
+                    "value": "true"
+                  }
+                },
+                "ratingsCount": 0,
+                "state": "PUBLISHED",
+                "title": "Messagerie acad\u00e9mique",
+                "typeId": 4
+              },
+              {
+                "averageRating": 0,
+                "description": "Acc\u00e8s \u00e0 SOGo du GIP RECIA - webmail, agenda et contacts                                                      courriel, courrier, \u00e9lectronique, webmail, professionnel, poster",
+                "favorite": false,
+                "fname": "CourrielRECIA",
+                "id": 53,
+                "keywords": [],
+                "name": "Messagerie du GIP RECIA",
+                "parameters": {
+                  "alternate": {
+                    "description": "",
+                    "name": "alternate",
+                    "value": "false"
+                  },
+                  "alternativeMaximizedLink": {
+                    "description": "",
+                    "name": "alternativeMaximizedLink",
+                    "value": "/portail/api/ExternalURLStats?fname=CourrielRECIA&service=https://sogo.recia.fr/"
+                  },
+                  "blockImpersonation": {
+                    "description": "",
+                    "name": "blockImpersonation",
+                    "value": "true"
+                  },
+                  "editable": {
+                    "description": "",
+                    "name": "editable",
+                    "value": "false"
+                  },
+                  "hasAbout": {
+                    "description": "",
+                    "name": "hasAbout",
+                    "value": "false"
+                  },
+                  "hasHelp": {
+                    "description": "",
+                    "name": "hasHelp",
+                    "value": "false"
+                  },
+                  "hideFromDesktop": {
+                    "description": "",
+                    "name": "hideFromDesktop",
+                    "value": "false"
+                  },
+                  "hideFromMobile": {
+                    "description": "",
+                    "name": "hideFromMobile",
+                    "value": "false"
+                  },
+                  "highlight": {
+                    "description": "",
+                    "name": "highlight",
+                    "value": "false"
+                  },
+                  "iconUrl": {
+                    "description": "",
+                    "name": "iconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/CourrielRECIA.svg"
+                  },
+                  "locale": {
+                    "description": "",
+                    "name": "locale",
+                    "value": "false"
+                  },
+                  "mobileIconUrl": {
+                    "description": "",
+                    "name": "mobileIconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/CourrielRECIA.svg"
+                  },
+                  "printable": {
+                    "description": "",
+                    "name": "printable",
+                    "value": "false"
+                  },
+                  "secure": {
+                    "description": "",
+                    "name": "secure",
+                    "value": "false"
+                  },
+                  "showChrome": {
+                    "description": "",
+                    "name": "showChrome",
+                    "value": "true"
+                  }
+                },
+                "ratingsCount": 0,
+                "state": "PUBLISHED",
+                "title": "Messagerie et agenda",
+                "typeId": 6
+              },
+              {
+                "averageRating": 0,
+                "description": "Acc\u00e8s aux ressources du CDI de l'\u00e9tablissement                                                               centre de documentation, information, biblioth\u00e8que, documentation, livres, scolaires, emprunter, multi-m\u00e9dia, ressources, num\u00e9riques, e-sidoc",
+                "favorite": false,
+                "fname": "MonCDI",
+                "id": 82,
+                "keywords": [],
+                "name": "Mon CDI",
+                "parameters": {
+                  "alternate": {
+                    "description": "",
+                    "name": "alternate",
+                    "value": "false"
+                  },
+                  "alternativeMaximizedLink": {
+                    "description": "",
+                    "name": "alternativeMaximizedLink",
+                    "value": "/portail/api/ExternalURLStats?fname=ESIDOC&service=/esco-apps-redirector/index.php?appli=ESIDOC"
+                  },
+                  "blockImpersonation": {
+                    "description": "",
+                    "name": "blockImpersonation",
+                    "value": "false"
+                  },
+                  "disableDynamicTitle": {
+                    "description": "",
+                    "name": "disableDynamicTitle",
+                    "value": "true"
+                  },
+                  "editable": {
+                    "description": "",
+                    "name": "editable",
+                    "value": "false"
+                  },
+                  "hasAbout": {
+                    "description": "",
+                    "name": "hasAbout",
+                    "value": "false"
+                  },
+                  "hasHelp": {
+                    "description": "",
+                    "name": "hasHelp",
+                    "value": "false"
+                  },
+                  "hideFromDesktop": {
+                    "description": "",
+                    "name": "hideFromDesktop",
+                    "value": "false"
+                  },
+                  "hideFromMobile": {
+                    "description": "",
+                    "name": "hideFromMobile",
+                    "value": "false"
+                  },
+                  "highlight": {
+                    "description": "",
+                    "name": "highlight",
+                    "value": "false"
+                  },
+                  "iconUrl": {
+                    "description": "",
+                    "name": "iconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/MonCDI.svg"
+                  },
+                  "mobileIconUrl": {
+                    "description": "",
+                    "name": "mobileIconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/MonCDI.svg"
+                  },
+                  "printable": {
+                    "description": "",
+                    "name": "printable",
+                    "value": "false"
+                  },
+                  "showChrome": {
+                    "description": "",
+                    "name": "showChrome",
+                    "value": "true"
+                  }
+                },
+                "ratingsCount": 0,
+                "state": "PUBLISHED",
+                "title": "Mon CDI",
+                "typeId": 4
+              },
+              {
+                "averageRating": 0,
+                "description": "Vid\u00e9o humoristique de pr\u00e9sentaiton de services NetO'Centre                                                     ENT, R\u00e9gion Centre-Val de Loire, acad\u00e9mie, Orl\u00e9ans, Tours, pr\u00e9sentation, information",
+                "favorite": false,
+                "fname": "VideoNOCWPP",
+                "id": 106,
+                "keywords": [],
+                "name": "NetO'Centre Vid\u00e9o",
+                "parameters": {
+                  "blockImpersonation": {
+                    "description": "",
+                    "name": "blockImpersonation",
+                    "value": "false"
+                  },
+                  "chromeStyle": {
+                    "description": "",
+                    "name": "chromeStyle",
+                    "value": "default"
+                  },
+                  "configurable": {
+                    "description": "",
+                    "name": "configurable",
+                    "value": "false"
+                  },
+                  "disableDynamicTitle": {
+                    "description": "",
+                    "name": "disableDynamicTitle",
+                    "value": "true"
+                  },
+                  "disablePortletEvents": {
+                    "description": "",
+                    "name": "disablePortletEvents",
+                    "value": "false"
+                  },
+                  "editable": {
+                    "description": "",
+                    "name": "editable",
+                    "value": "false"
+                  },
+                  "hasAbout": {
+                    "description": "",
+                    "name": "hasAbout",
+                    "value": "false"
+                  },
+                  "hasHelp": {
+                    "description": "",
+                    "name": "hasHelp",
+                    "value": "false"
+                  },
+                  "hideFromMobile": {
+                    "description": "",
+                    "name": "hideFromMobile",
+                    "value": "false"
+                  },
+                  "iconUrl": {
+                    "description": "",
+                    "name": "iconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/VideoNOCWPP.svg"
+                  },
+                  "mobileIconUrl": {
+                    "description": "",
+                    "name": "mobileIconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/VideoNOCWPP.svg"
+                  },
+                  "printable": {
+                    "description": "",
+                    "name": "printable",
+                    "value": "false"
+                  }
+                },
+                "ratingsCount": 0,
+                "state": "PUBLISHED",
+                "title": "NetO'Centre Vid\u00e9o",
+                "typeId": 7
+              },
+              {
+                "averageRating": 0,
+                "description": "Outil permettant de concevoir des sondages plus ou moins complexes                                           enqu\u00eates, sondages, limesurvey",
+                "favorite": false,
+                "fname": "Limesurvey",
+                "id": 135,
+                "keywords": [],
+                "name": "Outil de sondages",
+                "parameters": {
+                  "alternate": {
+                    "description": "",
+                    "name": "alternate",
+                    "value": "false"
+                  },
+                  "blockImpersonation": {
+                    "description": "",
+                    "name": "blockImpersonation",
+                    "value": "true"
+                  },
+                  "chromeStyle": {
+                    "description": "",
+                    "name": "chromeStyle",
+                    "value": "default"
+                  },
+                  "configurable": {
+                    "description": "",
+                    "name": "configurable",
+                    "value": "false"
+                  },
+                  "disableDynamicTitle": {
+                    "description": "",
+                    "name": "disableDynamicTitle",
+                    "value": "true"
+                  },
+                  "disablePortletEvents": {
+                    "description": "",
+                    "name": "disablePortletEvents",
+                    "value": "false"
+                  },
+                  "editable": {
+                    "description": "",
+                    "name": "editable",
+                    "value": "false"
+                  },
+                  "hasAbout": {
+                    "description": "",
+                    "name": "hasAbout",
+                    "value": "false"
+                  },
+                  "hasHelp": {
+                    "description": "",
+                    "name": "hasHelp",
+                    "value": "false"
+                  },
+                  "hideFromDesktop": {
+                    "description": "",
+                    "name": "hideFromDesktop",
+                    "value": "false"
+                  },
+                  "hideFromMobile": {
+                    "description": "",
+                    "name": "hideFromMobile",
+                    "value": "false"
+                  },
+                  "highlight": {
+                    "description": "",
+                    "name": "highlight",
+                    "value": "false"
+                  },
+                  "iconUrl": {
+                    "description": "",
+                    "name": "iconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/Limesurvey.svg"
+                  },
+                  "locale": {
+                    "description": "",
+                    "name": "locale",
+                    "value": "false"
+                  },
+                  "mobileIconUrl": {
+                    "description": "",
+                    "name": "mobileIconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/Limesurvey.svg"
+                  },
+                  "printable": {
+                    "description": "",
+                    "name": "printable",
+                    "value": "false"
+                  },
+                  "secure": {
+                    "description": "",
+                    "name": "secure",
+                    "value": "false"
+                  },
+                  "showChrome": {
+                    "description": "",
+                    "name": "showChrome",
+                    "value": "true"
+                  }
+                },
+                "ratingsCount": 0,
+                "state": "PUBLISHED",
+                "title": "Outil de sondages",
+                "typeId": 6
+              },
+              {
+                "averageRating": 0,
+                "description": "Gestion et publication de contenus (Actualit\u00e9s, Flash information, Ressources, etc...)                       publier, annonces, flash-infos, documents, \u00e9dition, \u00e9diter, mod\u00e9ration, mod\u00e9rer",
+                "favorite": false,
+                "fname": "PublicationContenus",
+                "id": 90,
+                "keywords": [],
+                "name": "Publication de contenus",
+                "parameters": {
+                  "alternate": {
+                    "description": "",
+                    "name": "alternate",
+                    "value": "false"
+                  },
+                  "alternativeMaximizedLink": {
+                    "description": "",
+                    "name": "alternativeMaximizedLink",
+                    "value": ""
+                  },
+                  "blockImpersonation": {
+                    "description": "",
+                    "name": "blockImpersonation",
+                    "value": "false"
+                  },
+                  "editable": {
+                    "description": "",
+                    "name": "editable",
+                    "value": "false"
+                  },
+                  "hasAbout": {
+                    "description": "",
+                    "name": "hasAbout",
+                    "value": "false"
+                  },
+                  "hasHelp": {
+                    "description": "",
+                    "name": "hasHelp",
+                    "value": "false"
+                  },
+                  "hideFromDesktop": {
+                    "description": "",
+                    "name": "hideFromDesktop",
+                    "value": "false"
+                  },
+                  "hideFromMobile": {
+                    "description": "",
+                    "name": "hideFromMobile",
+                    "value": "false"
+                  },
+                  "highlight": {
+                    "description": "",
+                    "name": "highlight",
+                    "value": "false"
+                  },
+                  "iconUrl": {
+                    "description": "",
+                    "name": "iconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/PublicationContenus.svg"
+                  },
+                  "locale": {
+                    "description": "",
+                    "name": "locale",
+                    "value": "false"
+                  },
+                  "mobileIconUrl": {
+                    "description": "",
+                    "name": "mobileIconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/PublicationContenus.svg"
+                  },
+                  "printable": {
+                    "description": "",
+                    "name": "printable",
+                    "value": "false"
+                  },
+                  "secure": {
+                    "description": "",
+                    "name": "secure",
+                    "value": "false"
+                  },
+                  "showChrome": {
+                    "description": "",
+                    "name": "showChrome",
+                    "value": "true"
+                  }
+                },
+                "ratingsCount": 0,
+                "state": "PUBLISHED",
+                "title": "Publication de contenus",
+                "typeId": 6
+              },
+              {
+                "averageRating": 0,
+                "description": "Les ressources disponibles dans le CDI de l'\u00e9tablissement                                                    centre de documentation, information, biblioth\u00e8que, documentation, livres, scolaires, emprunt, emprunter, multi-m\u00e9dia, ressources, num\u00e9riques, PMB",
+                "favorite": false,
+                "fname": "PMB_LesCharmilles",
+                "id": 88,
+                "keywords": [],
+                "name": "Ressources du CDI",
+                "parameters": {
+                  "alternate": {
+                    "description": "",
+                    "name": "alternate",
+                    "value": "false"
+                  },
+                  "alternativeMaximizedLink": {
+                    "description": "",
+                    "name": "alternativeMaximizedLink",
+                    "value": "/portail/api/ExternalURLStats?fname=PMB&service=http://lp-charmilles-chateauroux.tice.ac-orleans-tours.fr/php5/pmb/opac_css/?database=DB_lp_charmilles_chateauroux_PHP5"
+                  },
+                  "blockImpersonation": {
+                    "description": "",
+                    "name": "blockImpersonation",
+                    "value": "true"
+                  },
+                  "disableDynamicTitle": {
+                    "description": "",
+                    "name": "disableDynamicTitle",
+                    "value": "true"
+                  },
+                  "editable": {
+                    "description": "",
+                    "name": "editable",
+                    "value": "false"
+                  },
+                  "hasAbout": {
+                    "description": "",
+                    "name": "hasAbout",
+                    "value": "false"
+                  },
+                  "hasHelp": {
+                    "description": "",
+                    "name": "hasHelp",
+                    "value": "false"
+                  },
+                  "hideFromDesktop": {
+                    "description": "",
+                    "name": "hideFromDesktop",
+                    "value": "false"
+                  },
+                  "hideFromMobile": {
+                    "description": "",
+                    "name": "hideFromMobile",
+                    "value": "false"
+                  },
+                  "highlight": {
+                    "description": "",
+                    "name": "highlight",
+                    "value": "false"
+                  },
+                  "iconUrl": {
+                    "description": "",
+                    "name": "iconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/PMB_LesCharmilles.svg"
+                  },
+                  "mobileIconUrl": {
+                    "description": "",
+                    "name": "mobileIconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/PMB_LesCharmilles.svg"
+                  },
+                  "printable": {
+                    "description": "",
+                    "name": "printable",
+                    "value": "false"
+                  },
+                  "showChrome": {
+                    "description": "",
+                    "name": "showChrome",
+                    "value": "true"
+                  }
+                },
+                "ratingsCount": 0,
+                "state": "PUBLISHED",
+                "title": "Ressources du CDI",
+                "typeId": 4
+              },
+              {
+                "averageRating": 0,
+                "description": "Informations sur la vie \u00e9tudiante \u00e0 l'ITS de Tours                                                           \u00e9tudiants, apprenti, social, informations, formations, h\u00e9bergement, bourses, aides, assistance",
+                "favorite": false,
+                "fname": "ITS-Tours_VieEtudiante",
+                "id": 134,
+                "keywords": [],
+                "name": "Vie \u00e9tudiante \u00e0 l'ITS",
+                "parameters": {
+                  "alternate": {
+                    "description": "",
+                    "name": "alternate",
+                    "value": "false"
+                  },
+                  "blockImpersonation": {
+                    "description": "",
+                    "name": "blockImpersonation",
+                    "value": "false"
+                  },
+                  "chromeStyle": {
+                    "description": "",
+                    "name": "chromeStyle",
+                    "value": "default"
+                  },
+                  "configurable": {
+                    "description": "",
+                    "name": "configurable",
+                    "value": "false"
+                  },
+                  "disableDynamicTitle": {
+                    "description": "",
+                    "name": "disableDynamicTitle",
+                    "value": "true"
+                  },
+                  "disablePortletEvents": {
+                    "description": "",
+                    "name": "disablePortletEvents",
+                    "value": "false"
+                  },
+                  "editable": {
+                    "description": "",
+                    "name": "editable",
+                    "value": "false"
+                  },
+                  "hasAbout": {
+                    "description": "",
+                    "name": "hasAbout",
+                    "value": "false"
+                  },
+                  "hasHelp": {
+                    "description": "",
+                    "name": "hasHelp",
+                    "value": "false"
+                  },
+                  "hideFromDesktop": {
+                    "description": "",
+                    "name": "hideFromDesktop",
+                    "value": "false"
+                  },
+                  "hideFromMobile": {
+                    "description": "",
+                    "name": "hideFromMobile",
+                    "value": "false"
+                  },
+                  "highlight": {
+                    "description": "",
+                    "name": "highlight",
+                    "value": "false"
+                  },
+                  "iconUrl": {
+                    "description": "",
+                    "name": "iconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/ItsTours_VieEtudiante.svg"
+                  },
+                  "mobileIconUrl": {
+                    "description": "",
+                    "name": "mobileIconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/ItsTours_VieEtudiante.svg"
+                  },
+                  "printable": {
+                    "description": "",
+                    "name": "printable",
+                    "value": "false"
+                  },
+                  "showChrome": {
+                    "description": "",
+                    "name": "showChrome",
+                    "value": "true"
+                  }
+                },
+                "ratingsCount": 0,
+                "state": "PUBLISHED",
+                "title": "Vie \u00e9tudiante \u00e0 l'ITS",
+                "typeId": 4
+              },
+              {
+                "averageRating": 0,
+                "description": "Message d'accueil pour l'ENT WebOcentre                                                                      ENT, R\u00e9gion Centre-Val de Loire, pr\u00e9sentation, information, GIP RECIA, EPN, Espaces Publics Num\u00e9riques",
+                "favorite": false,
+                "fname": "MessageAccueilWoC",
+                "id": 137,
+                "keywords": [],
+                "name": "WebOcentre",
+                "parameters": {
+                  "alternate": {
+                    "description": "",
+                    "name": "alternate",
+                    "value": "false"
+                  },
+                  "blockImpersonation": {
+                    "description": "",
+                    "name": "blockImpersonation",
+                    "value": "false"
+                  },
+                  "chromeStyle": {
+                    "description": "",
+                    "name": "chromeStyle",
+                    "value": "default"
+                  },
+                  "configurable": {
+                    "description": "",
+                    "name": "configurable",
+                    "value": "false"
+                  },
+                  "disableDynamicTitle": {
+                    "description": "",
+                    "name": "disableDynamicTitle",
+                    "value": "true"
+                  },
+                  "disablePortletEvents": {
+                    "description": "",
+                    "name": "disablePortletEvents",
+                    "value": "false"
+                  },
+                  "editable": {
+                    "description": "",
+                    "name": "editable",
+                    "value": "false"
+                  },
+                  "hasAbout": {
+                    "description": "",
+                    "name": "hasAbout",
+                    "value": "false"
+                  },
+                  "hasHelp": {
+                    "description": "",
+                    "name": "hasHelp",
+                    "value": "false"
+                  },
+                  "hideFromDesktop": {
+                    "description": "",
+                    "name": "hideFromDesktop",
+                    "value": "false"
+                  },
+                  "hideFromMobile": {
+                    "description": "",
+                    "name": "hideFromMobile",
+                    "value": "false"
+                  },
+                  "highlight": {
+                    "description": "",
+                    "name": "highlight",
+                    "value": "false"
+                  },
+                  "iconUrl": {
+                    "description": "",
+                    "name": "iconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/MessageAccueilWoC.svg"
+                  },
+                  "mobileIconUrl": {
+                    "description": "",
+                    "name": "mobileIconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/MessageAccueilWoC.svg"
+                  },
+                  "printable": {
+                    "description": "",
+                    "name": "printable",
+                    "value": "false"
+                  },
+                  "showChrome": {
+                    "description": "",
+                    "name": "showChrome",
+                    "value": "true"
+                  }
+                },
+                "ratingsCount": 0,
+                "state": "PUBLISHED",
+                "title": "WebOcentre",
+                "typeId": 4
+              },
+              {
+                "averageRating": 0,
+                "description": "Aides, infos, bons plans : le pass des jeunes en Centre-Val de Loire !                                       R\u00e9gion, cin\u00e9ma, culture, loisirs",
+                "favorite": false,
+                "fname": "YEPS",
+                "id": 110,
+                "keywords": [],
+                "name": "YEP'S",
+                "parameters": {
+                  "alternate": {
+                    "description": "",
+                    "name": "alternate",
+                    "value": "false"
+                  },
+                  "alternativeMaximizedLink": {
+                    "description": "",
+                    "name": "alternativeMaximizedLink",
+                    "value": "/portail/api/ExternalURLStats?fname=YEPS&service=https://ent.yeps.fr/shibboleth_connect"
+                  },
+                  "blockImpersonation": {
+                    "description": "",
+                    "name": "blockImpersonation",
+                    "value": "true"
+                  },
+                  "editable": {
+                    "description": "",
+                    "name": "editable",
+                    "value": "false"
+                  },
+                  "hasAbout": {
+                    "description": "",
+                    "name": "hasAbout",
+                    "value": "false"
+                  },
+                  "hasHelp": {
+                    "description": "",
+                    "name": "hasHelp",
+                    "value": "false"
+                  },
+                  "hideFromDesktop": {
+                    "description": "",
+                    "name": "hideFromDesktop",
+                    "value": "false"
+                  },
+                  "hideFromMobile": {
+                    "description": "",
+                    "name": "hideFromMobile",
+                    "value": "false"
+                  },
+                  "highlight": {
+                    "description": "",
+                    "name": "highlight",
+                    "value": "false"
+                  },
+                  "iconUrl": {
+                    "description": "",
+                    "name": "iconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/YEPS.svg"
+                  },
+                  "locale": {
+                    "description": "",
+                    "name": "locale",
+                    "value": "false"
+                  },
+                  "mobileIconUrl": {
+                    "description": "",
+                    "name": "mobileIconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/YEPS.svg"
+                  },
+                  "printable": {
+                    "description": "",
+                    "name": "printable",
+                    "value": "false"
+                  },
+                  "secure": {
+                    "description": "",
+                    "name": "secure",
+                    "value": "false"
+                  },
+                  "showChrome": {
+                    "description": "",
+                    "name": "showChrome",
+                    "value": "true"
+                  }
+                },
+                "ratingsCount": 0,
+                "state": "PUBLISHED",
+                "title": "YEP'S",
+                "typeId": 6
+              }
+            ],
+            "subcategories": []
+          },
+          {
+            "description": "Services pour les d\u00e9veloppeurs",
+            "id": "local.11",
+            "name": "D\u00e9veloppement",
+            "portlets": [
+              {
+                "averageRating": 0,
+                "description": "Activer/d\u00e9sactiver l'aggr\u00e9gation des CSS/JavaScript",
+                "favorite": false,
+                "fname": "toggle-resources-aggregation",
+                "id": 36,
+                "keywords": [],
+                "name": "Activer/d\u00e9sactiver l'aggr\u00e9gation des CSS/JavaScript",
+                "parameters": {
+                  "iconUrl": {
+                    "description": "",
+                    "name": "iconUrl",
+                    "value": "https://ent.recia.fr/ResourceServingWebapp/rs/tango/0.8.90/32x32/categories/preferences-system.png"
+                  }
+                },
+                "ratingsCount": 0,
+                "state": "PUBLISHED",
+                "title": "Activer/d\u00e9sactiver l'aggr\u00e9gation des CSS/JavaScript",
+                "typeId": 7
+              },
+              {
+                "averageRating": 0,
+                "description": "Outil pour voir les attributs et en-t\u00eates de requ\u00eates",
+                "favorite": false,
+                "fname": "snooper",
+                "id": 32,
+                "keywords": [],
+                "name": "Espion",
+                "parameters": {
+                  "iconUrl": {
+                    "description": "",
+                    "name": "iconUrl",
+                    "value": "https://ent.recia.fr/ResourceServingWebapp/rs/tango/0.8.90/32x32/categories/applications-system.png"
+                  }
+                },
+                "ratingsCount": 0,
+                "state": "PUBLISHED",
+                "title": "Espion",
+                "typeId": 7
+              },
+              {
+                "averageRating": 0,
+                "description": "Tests uPortal's ability to pass a valid CAS ticket to a portlet through the UserInfo map.",
+                "favorite": false,
+                "fname": "portlet-cas-test",
+                "id": 125,
+                "keywords": [],
+                "name": "Portlet CAS Test",
+                "parameters": {
+                  "iconUrl": {
+                    "description": "",
+                    "name": "iconUrl",
+                    "value": "https://ent.recia.fr/ResourceServingWebapp/rs/tango/0.8.90/32x32/categories/applications-development.png"
+                  }
+                },
+                "ratingsCount": 0,
+                "state": "PUBLISHED",
+                "title": "Portlet CAS Test",
+                "typeId": 7
+              },
+              {
+                "averageRating": 0,
+                "description": "Portlet d'import-export d'entit\u00e9s",
+                "favorite": false,
+                "fname": "ImportExportPortlet",
+                "id": 2,
+                "keywords": [],
+                "name": "Portlet d'import-export",
+                "parameters": {
+                  "disableDynamicTitle": {
+                    "description": "",
+                    "name": "disableDynamicTitle",
+                    "value": "false"
+                  },
+                  "iconUrl": {
+                    "description": "",
+                    "name": "iconUrl",
+                    "value": "https://ent.recia.fr/ResourceServingWebapp/rs/tango/0.8.90/32x32/categories/applications-system.png"
+                  }
+                },
+                "ratingsCount": 0,
+                "state": "PUBLISHED",
+                "title": "Portlet d'import-export",
+                "typeId": 7
+              }
+            ],
+            "subcategories": []
+          },
+          {
+            "description": "Services en R\u00e9gion Centre-Val de Loire",
+            "id": "local.30",
+            "name": "En R\u00e9gion Centre-Val de Loire",
+            "portlets": [
+              {
+                "averageRating": 0,
+                "description": "Actualit\u00e9s en R\u00e9gion Centre-Val de Loire                                                                     nouvelles, annonces",
+                "favorite": false,
+                "fname": "ActualitesRegion",
+                "id": 44,
+                "keywords": [],
+                "name": "Actualit\u00e9s R\u00e9gion",
+                "parameters": {
+                  "alternate": {
+                    "description": "",
+                    "name": "alternate",
+                    "value": "false"
+                  },
+                  "blockImpersonation": {
+                    "description": "",
+                    "name": "blockImpersonation",
+                    "value": "false"
+                  },
+                  "disableDynamicTitle": {
+                    "description": "",
+                    "name": "disableDynamicTitle",
+                    "value": "true"
+                  },
+                  "editable": {
+                    "description": "",
+                    "name": "editable",
+                    "value": "false"
+                  },
+                  "hasAbout": {
+                    "description": "",
+                    "name": "hasAbout",
+                    "value": "false"
+                  },
+                  "hasHelp": {
+                    "description": "",
+                    "name": "hasHelp",
+                    "value": "false"
+                  },
+                  "hideFromDesktop": {
+                    "description": "",
+                    "name": "hideFromDesktop",
+                    "value": "false"
+                  },
+                  "hideFromMobile": {
+                    "description": "",
+                    "name": "hideFromMobile",
+                    "value": "false"
+                  },
+                  "highlight": {
+                    "description": "",
+                    "name": "highlight",
+                    "value": "false"
+                  },
+                  "iconUrl": {
+                    "description": "",
+                    "name": "iconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/ActualitesRegion.svg"
+                  },
+                  "locale": {
+                    "description": "",
+                    "name": "locale",
+                    "value": "false"
+                  },
+                  "mobileIconUrl": {
+                    "description": "",
+                    "name": "mobileIconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/ActualitesRegion.svg"
+                  },
+                  "printable": {
+                    "description": "",
+                    "name": "printable",
+                    "value": "false"
+                  },
+                  "secure": {
+                    "description": "",
+                    "name": "secure",
+                    "value": "false"
+                  },
+                  "showChrome": {
+                    "description": "",
+                    "name": "showChrome",
+                    "value": "true"
+                  }
+                },
+                "ratingsCount": 0,
+                "state": "PUBLISHED",
+                "title": "Actualit\u00e9s en R\u00e9gion",
+                "typeId": 7
+              },
+              {
+                "averageRating": 0,
+                "description": "Aides et informations r\u00e9gionales pour les CFA                                                                R\u00e9gion Centre-Val de Loire, financi\u00e8re, \u00e9quipements, subventions, CFA",
+                "favorite": false,
+                "fname": "aidesInfosCFA",
+                "id": 115,
+                "keywords": [],
+                "name": "Aides et informations r\u00e9gionales",
+                "parameters": {
+                  "alternate": {
+                    "description": "",
+                    "name": "alternate",
+                    "value": "false"
+                  },
+                  "blockImpersonation": {
+                    "description": "",
+                    "name": "blockImpersonation",
+                    "value": "false"
+                  },
+                  "disableDynamicTitle": {
+                    "description": "",
+                    "name": "disableDynamicTitle",
+                    "value": "true"
+                  },
+                  "editable": {
+                    "description": "",
+                    "name": "editable",
+                    "value": "false"
+                  },
+                  "hasAbout": {
+                    "description": "",
+                    "name": "hasAbout",
+                    "value": "false"
+                  },
+                  "hasHelp": {
+                    "description": "",
+                    "name": "hasHelp",
+                    "value": "false"
+                  },
+                  "hideFromDesktop": {
+                    "description": "",
+                    "name": "hideFromDesktop",
+                    "value": "false"
+                  },
+                  "hideFromMobile": {
+                    "description": "",
+                    "name": "hideFromMobile",
+                    "value": "false"
+                  },
+                  "highlight": {
+                    "description": "",
+                    "name": "highlight",
+                    "value": "false"
+                  },
+                  "iconUrl": {
+                    "description": "",
+                    "name": "iconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/aidesInfosCFA.svg"
+                  },
+                  "locale": {
+                    "description": "",
+                    "name": "locale",
+                    "value": "false"
+                  },
+                  "mobileIconUrl": {
+                    "description": "",
+                    "name": "mobileIconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/aidesInfosCFA.svg"
+                  },
+                  "printable": {
+                    "description": "",
+                    "name": "printable",
+                    "value": "false"
+                  },
+                  "secure": {
+                    "description": "",
+                    "name": "secure",
+                    "value": "false"
+                  },
+                  "showChrome": {
+                    "description": "",
+                    "name": "showChrome",
+                    "value": "true"
+                  }
+                },
+                "ratingsCount": 0,
+                "state": "PUBLISHED",
+                "title": "Aides et informations r\u00e9gionales",
+                "typeId": 7
+              },
+              {
+                "averageRating": 0,
+                "description": "Les derni\u00e8res actualit\u00e9s en R\u00e9gion Centre-Val de Loire                                                       nouvelles, annonces",
+                "favorite": false,
+                "fname": "ResumeActualitesRegion",
+                "id": 95,
+                "keywords": [],
+                "name": "Derni\u00e8res actualit\u00e9s en R\u00e9gion",
+                "parameters": {
+                  "alternate": {
+                    "description": "",
+                    "name": "alternate",
+                    "value": "false"
+                  },
+                  "blockImpersonation": {
+                    "description": "",
+                    "name": "blockImpersonation",
+                    "value": "false"
+                  },
+                  "disableDynamicTitle": {
+                    "description": "",
+                    "name": "disableDynamicTitle",
+                    "value": "true"
+                  },
+                  "editable": {
+                    "description": "",
+                    "name": "editable",
+                    "value": "false"
+                  },
+                  "hasAbout": {
+                    "description": "",
+                    "name": "hasAbout",
+                    "value": "false"
+                  },
+                  "hasHelp": {
+                    "description": "",
+                    "name": "hasHelp",
+                    "value": "false"
+                  },
+                  "hideFromDesktop": {
+                    "description": "",
+                    "name": "hideFromDesktop",
+                    "value": "false"
+                  },
+                  "hideFromMobile": {
+                    "description": "",
+                    "name": "hideFromMobile",
+                    "value": "false"
+                  },
+                  "highlight": {
+                    "description": "",
+                    "name": "highlight",
+                    "value": "false"
+                  },
+                  "iconUrl": {
+                    "description": "",
+                    "name": "iconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/ResumeActualitesRegion.svg"
+                  },
+                  "locale": {
+                    "description": "",
+                    "name": "locale",
+                    "value": "false"
+                  },
+                  "mobileIconUrl": {
+                    "description": "",
+                    "name": "mobileIconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/ResumeActualitesRegion.svg"
+                  },
+                  "printable": {
+                    "description": "",
+                    "name": "printable",
+                    "value": "false"
+                  },
+                  "secure": {
+                    "description": "",
+                    "name": "secure",
+                    "value": "false"
+                  },
+                  "showChrome": {
+                    "description": "",
+                    "name": "showChrome",
+                    "value": "true"
+                  }
+                },
+                "ratingsCount": 0,
+                "state": "PUBLISHED",
+                "title": "Derni\u00e8res actualit\u00e9s en R\u00e9gion",
+                "typeId": 7
+              },
+              {
+                "averageRating": 0,
+                "description": "Description du projet NetO'centre dans les lyc\u00e9es                                                            ENT, R\u00e9gion Centre-Val de Loire, acad\u00e9mie, Orl\u00e9ans, Tours, pr\u00e9sentation, information",
+                "favorite": false,
+                "fname": "accueil-lycees",
+                "id": 114,
+                "keywords": [],
+                "name": "Description NetO'centre",
+                "parameters": {
+                  "alternate": {
+                    "description": "",
+                    "name": "alternate",
+                    "value": "false"
+                  },
+                  "blockImpersonation": {
+                    "description": "",
+                    "name": "blockImpersonation",
+                    "value": "false"
+                  },
+                  "disableDynamicTitle": {
+                    "description": "",
+                    "name": "disableDynamicTitle",
+                    "value": "true"
+                  },
+                  "editable": {
+                    "description": "",
+                    "name": "editable",
+                    "value": "false"
+                  },
+                  "hasAbout": {
+                    "description": "",
+                    "name": "hasAbout",
+                    "value": "false"
+                  },
+                  "hasHelp": {
+                    "description": "",
+                    "name": "hasHelp",
+                    "value": "false"
+                  },
+                  "hideFromDesktop": {
+                    "description": "",
+                    "name": "hideFromDesktop",
+                    "value": "false"
+                  },
+                  "hideFromMobile": {
+                    "description": "",
+                    "name": "hideFromMobile",
+                    "value": "false"
+                  },
+                  "highlight": {
+                    "description": "",
+                    "name": "highlight",
+                    "value": "false"
+                  },
+                  "iconUrl": {
+                    "description": "",
+                    "name": "iconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/accueil-lycees.svg"
+                  },
+                  "locale": {
+                    "description": "",
+                    "name": "locale",
+                    "value": "false"
+                  },
+                  "mobileIconUrl": {
+                    "description": "",
+                    "name": "mobileIconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/accueil-lycees.svg"
+                  },
+                  "printable": {
+                    "description": "",
+                    "name": "printable",
+                    "value": "false"
+                  },
+                  "secure": {
+                    "description": "",
+                    "name": "secure",
+                    "value": "false"
+                  },
+                  "showChrome": {
+                    "description": "",
+                    "name": "showChrome",
+                    "value": "true"
+                  }
+                },
+                "ratingsCount": 0,
+                "state": "PUBLISHED",
+                "title": "Description de NetO'centre",
+                "typeId": 4
+              },
+              {
+                "averageRating": 0,
+                "description": "Description du projet NetO'centre dans les CFA                                                               ENT, R\u00e9gion Centre-Val de Loire, pr\u00e9sentation, information",
+                "favorite": false,
+                "fname": "accueil-cfa",
+                "id": 112,
+                "keywords": [],
+                "name": "Description de NetO'centre",
+                "parameters": {
+                  "alternate": {
+                    "description": "",
+                    "name": "alternate",
+                    "value": "false"
+                  },
+                  "blockImpersonation": {
+                    "description": "",
+                    "name": "blockImpersonation",
+                    "value": "false"
+                  },
+                  "disableDynamicTitle": {
+                    "description": "",
+                    "name": "disableDynamicTitle",
+                    "value": "true"
+                  },
+                  "editable": {
+                    "description": "",
+                    "name": "editable",
+                    "value": "false"
+                  },
+                  "hasAbout": {
+                    "description": "",
+                    "name": "hasAbout",
+                    "value": "false"
+                  },
+                  "hasHelp": {
+                    "description": "",
+                    "name": "hasHelp",
+                    "value": "false"
+                  },
+                  "hideFromDesktop": {
+                    "description": "",
+                    "name": "hideFromDesktop",
+                    "value": "false"
+                  },
+                  "hideFromMobile": {
+                    "description": "",
+                    "name": "hideFromMobile",
+                    "value": "false"
+                  },
+                  "highlight": {
+                    "description": "",
+                    "name": "highlight",
+                    "value": "false"
+                  },
+                  "iconUrl": {
+                    "description": "",
+                    "name": "iconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/accueil-cfa.svg"
+                  },
+                  "locale": {
+                    "description": "",
+                    "name": "locale",
+                    "value": "false"
+                  },
+                  "mobileIconUrl": {
+                    "description": "",
+                    "name": "mobileIconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/accueil-cfa.svg"
+                  },
+                  "printable": {
+                    "description": "",
+                    "name": "printable",
+                    "value": "false"
+                  },
+                  "secure": {
+                    "description": "",
+                    "name": "secure",
+                    "value": "false"
+                  },
+                  "showChrome": {
+                    "description": "",
+                    "name": "showChrome",
+                    "value": "true"
+                  }
+                },
+                "ratingsCount": 0,
+                "state": "PUBLISHED",
+                "title": "Description de NetO'centre",
+                "typeId": 4
+              },
+              {
+                "averageRating": 0,
+                "description": "Lettre d'information pour les utilisateurs de l'ENT                                                          NetO'Centre, R\u00e9gion Centre-Val de Loire, nouveaut\u00e9s, portail, applications, services",
+                "favorite": false,
+                "fname": "LettreActualites",
+                "id": 77,
+                "keywords": [],
+                "name": "Lettre d'actualit\u00e9s",
+                "parameters": {
+                  "alternate": {
+                    "description": "",
+                    "name": "alternate",
+                    "value": "false"
+                  },
+                  "blockImpersonation": {
+                    "description": "",
+                    "name": "blockImpersonation",
+                    "value": "false"
+                  },
+                  "disableDynamicTitle": {
+                    "description": "",
+                    "name": "disableDynamicTitle",
+                    "value": "true"
+                  },
+                  "editable": {
+                    "description": "",
+                    "name": "editable",
+                    "value": "false"
+                  },
+                  "hasAbout": {
+                    "description": "",
+                    "name": "hasAbout",
+                    "value": "false"
+                  },
+                  "hasHelp": {
+                    "description": "",
+                    "name": "hasHelp",
+                    "value": "false"
+                  },
+                  "hideFromDesktop": {
+                    "description": "",
+                    "name": "hideFromDesktop",
+                    "value": "false"
+                  },
+                  "hideFromMobile": {
+                    "description": "",
+                    "name": "hideFromMobile",
+                    "value": "false"
+                  },
+                  "highlight": {
+                    "description": "",
+                    "name": "highlight",
+                    "value": "false"
+                  },
+                  "iconUrl": {
+                    "description": "",
+                    "name": "iconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/LettreActualites.svg"
+                  },
+                  "mobileIconUrl": {
+                    "description": "",
+                    "name": "mobileIconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/LettreActualites.svg"
+                  },
+                  "printable": {
+                    "description": "",
+                    "name": "printable",
+                    "value": "false"
+                  },
+                  "showChrome": {
+                    "description": "",
+                    "name": "showChrome",
+                    "value": "true"
+                  }
+                },
+                "ratingsCount": 0,
+                "state": "PUBLISHED",
+                "title": "Lettre d'actualit\u00e9s",
+                "typeId": 4
+              },
+              {
+                "averageRating": 0,
+                "description": "Liste des logiciels disponibles dans le catalogue OPSI                                                       maintenance, administration, administrateur, informatique, itop, CSL, Correspondant Support Local, assistance, ordinateur, PC",
+                "favorite": false,
+                "fname": "Catalogue_OPSI",
+                "id": 132,
+                "keywords": [],
+                "name": "Logiciels disponibles",
+                "parameters": {
+                  "alternate": {
+                    "description": "",
+                    "name": "alternate",
+                    "value": "false"
+                  },
+                  "alternativeMaximizedLink": {
+                    "description": "",
+                    "name": "alternativeMaximizedLink",
+                    "value": "/portail/api/ExternalURLStats?fname=Catalogue_OPSI&service=https://www.escolan.recia.fr/opsi-catalogue/"
+                  },
+                  "blockImpersonation": {
+                    "description": "",
+                    "name": "blockImpersonation",
+                    "value": "true"
+                  },
+                  "editable": {
+                    "description": "",
+                    "name": "editable",
+                    "value": "false"
+                  },
+                  "hasAbout": {
+                    "description": "",
+                    "name": "hasAbout",
+                    "value": "false"
+                  },
+                  "hasHelp": {
+                    "description": "",
+                    "name": "hasHelp",
+                    "value": "false"
+                  },
+                  "hideFromDesktop": {
+                    "description": "",
+                    "name": "hideFromDesktop",
+                    "value": "false"
+                  },
+                  "hideFromMobile": {
+                    "description": "",
+                    "name": "hideFromMobile",
+                    "value": "false"
+                  },
+                  "highlight": {
+                    "description": "",
+                    "name": "highlight",
+                    "value": "false"
+                  },
+                  "iconUrl": {
+                    "description": "",
+                    "name": "iconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/Catalogue_OPSI.svg"
+                  },
+                  "locale": {
+                    "description": "",
+                    "name": "locale",
+                    "value": "false"
+                  },
+                  "mobileIconUrl": {
+                    "description": "",
+                    "name": "mobileIconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/Catalogue_OPSI.svg"
+                  },
+                  "printable": {
+                    "description": "",
+                    "name": "printable",
+                    "value": "false"
+                  },
+                  "secure": {
+                    "description": "",
+                    "name": "secure",
+                    "value": "false"
+                  },
+                  "showChrome": {
+                    "description": "",
+                    "name": "showChrome",
+                    "value": "true"
+                  }
+                },
+                "ratingsCount": 0,
+                "state": "PUBLISHED",
+                "title": "Logiciels disponibles",
+                "typeId": 6
+              },
+              {
+                "averageRating": 0,
+                "description": "Informations sur le projet de maintenance informatique dans les lyc\u00e9es                                       administration, administrateur, itop, CSL, Correspondant Support Local, assistance, ordinateurs, PC, logiciels",
+                "favorite": false,
+                "fname": "MILycees",
+                "id": 136,
+                "keywords": [],
+                "name": "Maintenance informatique des lyc\u00e9es",
+                "parameters": {
+                  "alternate": {
+                    "description": "",
+                    "name": "alternate",
+                    "value": "false"
+                  },
+                  "blockImpersonation": {
+                    "description": "",
+                    "name": "blockImpersonation",
+                    "value": "true"
+                  },
+                  "chromeStyle": {
+                    "description": "",
+                    "name": "chromeStyle",
+                    "value": "default"
+                  },
+                  "configurable": {
+                    "description": "",
+                    "name": "configurable",
+                    "value": "false"
+                  },
+                  "disableDynamicTitle": {
+                    "description": "",
+                    "name": "disableDynamicTitle",
+                    "value": "true"
+                  },
+                  "disablePortletEvents": {
+                    "description": "",
+                    "name": "disablePortletEvents",
+                    "value": "false"
+                  },
+                  "editable": {
+                    "description": "",
+                    "name": "editable",
+                    "value": "false"
+                  },
+                  "hasAbout": {
+                    "description": "",
+                    "name": "hasAbout",
+                    "value": "false"
+                  },
+                  "hasHelp": {
+                    "description": "",
+                    "name": "hasHelp",
+                    "value": "false"
+                  },
+                  "hideFromDesktop": {
+                    "description": "",
+                    "name": "hideFromDesktop",
+                    "value": "false"
+                  },
+                  "hideFromMobile": {
+                    "description": "",
+                    "name": "hideFromMobile",
+                    "value": "false"
+                  },
+                  "highlight": {
+                    "description": "",
+                    "name": "highlight",
+                    "value": "false"
+                  },
+                  "iconUrl": {
+                    "description": "",
+                    "name": "iconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/MILycees.svg"
+                  },
+                  "mobileIconUrl": {
+                    "description": "",
+                    "name": "mobileIconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/MILycees.svg"
+                  },
+                  "printable": {
+                    "description": "",
+                    "name": "printable",
+                    "value": "false"
+                  },
+                  "showChrome": {
+                    "description": "",
+                    "name": "showChrome",
+                    "value": "true"
+                  }
+                },
+                "ratingsCount": 0,
+                "state": "PUBLISHED",
+                "title": "Maintenance informatique des lyc\u00e9es",
+                "typeId": 4
+              },
+              {
+                "averageRating": 0,
+                "description": "Vid\u00e9o humoristique de pr\u00e9sentaiton de services NetO'Centre                                                     ENT, R\u00e9gion Centre-Val de Loire, acad\u00e9mie, Orl\u00e9ans, Tours, pr\u00e9sentation, information",
+                "favorite": false,
+                "fname": "VideoNOCWPP",
+                "id": 106,
+                "keywords": [],
+                "name": "NetO'Centre Vid\u00e9o",
+                "parameters": {
+                  "blockImpersonation": {
+                    "description": "",
+                    "name": "blockImpersonation",
+                    "value": "false"
+                  },
+                  "chromeStyle": {
+                    "description": "",
+                    "name": "chromeStyle",
+                    "value": "default"
+                  },
+                  "configurable": {
+                    "description": "",
+                    "name": "configurable",
+                    "value": "false"
+                  },
+                  "disableDynamicTitle": {
+                    "description": "",
+                    "name": "disableDynamicTitle",
+                    "value": "true"
+                  },
+                  "disablePortletEvents": {
+                    "description": "",
+                    "name": "disablePortletEvents",
+                    "value": "false"
+                  },
+                  "editable": {
+                    "description": "",
+                    "name": "editable",
+                    "value": "false"
+                  },
+                  "hasAbout": {
+                    "description": "",
+                    "name": "hasAbout",
+                    "value": "false"
+                  },
+                  "hasHelp": {
+                    "description": "",
+                    "name": "hasHelp",
+                    "value": "false"
+                  },
+                  "hideFromMobile": {
+                    "description": "",
+                    "name": "hideFromMobile",
+                    "value": "false"
+                  },
+                  "iconUrl": {
+                    "description": "",
+                    "name": "iconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/VideoNOCWPP.svg"
+                  },
+                  "mobileIconUrl": {
+                    "description": "",
+                    "name": "mobileIconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/VideoNOCWPP.svg"
+                  },
+                  "printable": {
+                    "description": "",
+                    "name": "printable",
+                    "value": "false"
+                  }
+                },
+                "ratingsCount": 0,
+                "state": "PUBLISHED",
+                "title": "NetO'Centre Vid\u00e9o",
+                "typeId": 7
+              },
+              {
+                "averageRating": 0,
+                "description": "Message d'accueil pour l'ENT WebOcentre                                                                      ENT, R\u00e9gion Centre-Val de Loire, pr\u00e9sentation, information, GIP RECIA, EPN, Espaces Publics Num\u00e9riques",
+                "favorite": false,
+                "fname": "MessageAccueilWoC",
+                "id": 137,
+                "keywords": [],
+                "name": "WebOcentre",
+                "parameters": {
+                  "alternate": {
+                    "description": "",
+                    "name": "alternate",
+                    "value": "false"
+                  },
+                  "blockImpersonation": {
+                    "description": "",
+                    "name": "blockImpersonation",
+                    "value": "false"
+                  },
+                  "chromeStyle": {
+                    "description": "",
+                    "name": "chromeStyle",
+                    "value": "default"
+                  },
+                  "configurable": {
+                    "description": "",
+                    "name": "configurable",
+                    "value": "false"
+                  },
+                  "disableDynamicTitle": {
+                    "description": "",
+                    "name": "disableDynamicTitle",
+                    "value": "true"
+                  },
+                  "disablePortletEvents": {
+                    "description": "",
+                    "name": "disablePortletEvents",
+                    "value": "false"
+                  },
+                  "editable": {
+                    "description": "",
+                    "name": "editable",
+                    "value": "false"
+                  },
+                  "hasAbout": {
+                    "description": "",
+                    "name": "hasAbout",
+                    "value": "false"
+                  },
+                  "hasHelp": {
+                    "description": "",
+                    "name": "hasHelp",
+                    "value": "false"
+                  },
+                  "hideFromDesktop": {
+                    "description": "",
+                    "name": "hideFromDesktop",
+                    "value": "false"
+                  },
+                  "hideFromMobile": {
+                    "description": "",
+                    "name": "hideFromMobile",
+                    "value": "false"
+                  },
+                  "highlight": {
+                    "description": "",
+                    "name": "highlight",
+                    "value": "false"
+                  },
+                  "iconUrl": {
+                    "description": "",
+                    "name": "iconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/MessageAccueilWoC.svg"
+                  },
+                  "mobileIconUrl": {
+                    "description": "",
+                    "name": "mobileIconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/MessageAccueilWoC.svg"
+                  },
+                  "printable": {
+                    "description": "",
+                    "name": "printable",
+                    "value": "false"
+                  },
+                  "showChrome": {
+                    "description": "",
+                    "name": "showChrome",
+                    "value": "true"
+                  }
+                },
+                "ratingsCount": 0,
+                "state": "PUBLISHED",
+                "title": "WebOcentre",
+                "typeId": 4
+              },
+              {
+                "averageRating": 0,
+                "description": "Aides, infos, bons plans : le pass des jeunes en Centre-Val de Loire !                                       R\u00e9gion, cin\u00e9ma, culture, loisirs",
+                "favorite": false,
+                "fname": "YEPS",
+                "id": 110,
+                "keywords": [],
+                "name": "YEP'S",
+                "parameters": {
+                  "alternate": {
+                    "description": "",
+                    "name": "alternate",
+                    "value": "false"
+                  },
+                  "alternativeMaximizedLink": {
+                    "description": "",
+                    "name": "alternativeMaximizedLink",
+                    "value": "/portail/api/ExternalURLStats?fname=YEPS&service=https://ent.yeps.fr/shibboleth_connect"
+                  },
+                  "blockImpersonation": {
+                    "description": "",
+                    "name": "blockImpersonation",
+                    "value": "true"
+                  },
+                  "editable": {
+                    "description": "",
+                    "name": "editable",
+                    "value": "false"
+                  },
+                  "hasAbout": {
+                    "description": "",
+                    "name": "hasAbout",
+                    "value": "false"
+                  },
+                  "hasHelp": {
+                    "description": "",
+                    "name": "hasHelp",
+                    "value": "false"
+                  },
+                  "hideFromDesktop": {
+                    "description": "",
+                    "name": "hideFromDesktop",
+                    "value": "false"
+                  },
+                  "hideFromMobile": {
+                    "description": "",
+                    "name": "hideFromMobile",
+                    "value": "false"
+                  },
+                  "highlight": {
+                    "description": "",
+                    "name": "highlight",
+                    "value": "false"
+                  },
+                  "iconUrl": {
+                    "description": "",
+                    "name": "iconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/YEPS.svg"
+                  },
+                  "locale": {
+                    "description": "",
+                    "name": "locale",
+                    "value": "false"
+                  },
+                  "mobileIconUrl": {
+                    "description": "",
+                    "name": "mobileIconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/YEPS.svg"
+                  },
+                  "printable": {
+                    "description": "",
+                    "name": "printable",
+                    "value": "false"
+                  },
+                  "secure": {
+                    "description": "",
+                    "name": "secure",
+                    "value": "false"
+                  },
+                  "showChrome": {
+                    "description": "",
+                    "name": "showChrome",
+                    "value": "true"
+                  }
+                },
+                "ratingsCount": 0,
+                "state": "PUBLISHED",
+                "title": "YEP'S",
+                "typeId": 6
+              }
+            ],
+            "subcategories": []
+          },
+          {
+            "description": "Services en Touraine",
+            "id": "local.31",
+            "name": "En Touraine",
+            "portlets": [
+              {
+                "averageRating": 0,
+                "description": "Actualit\u00e9s de la Touraine, mon d\u00e9partement                                                                   Indre-et-Loire, nouvelles, annonces",
+                "favorite": false,
+                "fname": "ActualitesCD37",
+                "id": 42,
+                "keywords": [],
+                "name": "Actualit\u00e9s en Touraine",
+                "parameters": {
+                  "alternate": {
+                    "description": "",
+                    "name": "alternate",
+                    "value": "false"
+                  },
+                  "blockImpersonation": {
+                    "description": "",
+                    "name": "blockImpersonation",
+                    "value": "false"
+                  },
+                  "disableDynamicTitle": {
+                    "description": "",
+                    "name": "disableDynamicTitle",
+                    "value": "true"
+                  },
+                  "editable": {
+                    "description": "",
+                    "name": "editable",
+                    "value": "false"
+                  },
+                  "hasAbout": {
+                    "description": "",
+                    "name": "hasAbout",
+                    "value": "false"
+                  },
+                  "hasHelp": {
+                    "description": "",
+                    "name": "hasHelp",
+                    "value": "false"
+                  },
+                  "hideFromDesktop": {
+                    "description": "",
+                    "name": "hideFromDesktop",
+                    "value": "false"
+                  },
+                  "hideFromMobile": {
+                    "description": "",
+                    "name": "hideFromMobile",
+                    "value": "false"
+                  },
+                  "highlight": {
+                    "description": "",
+                    "name": "highlight",
+                    "value": "false"
+                  },
+                  "iconUrl": {
+                    "description": "",
+                    "name": "iconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/ActualitesCD37.svg"
+                  },
+                  "locale": {
+                    "description": "",
+                    "name": "locale",
+                    "value": "false"
+                  },
+                  "mobileIconUrl": {
+                    "description": "",
+                    "name": "mobileIconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/ActualitesCD37.svg"
+                  },
+                  "printable": {
+                    "description": "",
+                    "name": "printable",
+                    "value": "false"
+                  },
+                  "secure": {
+                    "description": "",
+                    "name": "secure",
+                    "value": "false"
+                  },
+                  "showChrome": {
+                    "description": "",
+                    "name": "showChrome",
+                    "value": "false"
+                  }
+                },
+                "ratingsCount": 0,
+                "state": "PUBLISHED",
+                "title": "Actualit\u00e9s en Touraine",
+                "typeId": 7
+              },
+              {
+                "averageRating": 0,
+                "description": "Derni\u00e8res actualit\u00e9s en Touraine, mon d\u00e9partement                                                            Indre-et-Loire, nouvelles, annonces",
+                "favorite": false,
+                "fname": "ResumeActualitesCD37",
+                "id": 93,
+                "keywords": [],
+                "name": "Derni\u00e8res actualit\u00e9s en Touraine",
+                "parameters": {
+                  "alternate": {
+                    "description": "",
+                    "name": "alternate",
+                    "value": "false"
+                  },
+                  "blockImpersonation": {
+                    "description": "",
+                    "name": "blockImpersonation",
+                    "value": "false"
+                  },
+                  "disableDynamicTitle": {
+                    "description": "",
+                    "name": "disableDynamicTitle",
+                    "value": "true"
+                  },
+                  "editable": {
+                    "description": "",
+                    "name": "editable",
+                    "value": "false"
+                  },
+                  "hasAbout": {
+                    "description": "",
+                    "name": "hasAbout",
+                    "value": "false"
+                  },
+                  "hasHelp": {
+                    "description": "",
+                    "name": "hasHelp",
+                    "value": "false"
+                  },
+                  "hideFromDesktop": {
+                    "description": "",
+                    "name": "hideFromDesktop",
+                    "value": "false"
+                  },
+                  "hideFromMobile": {
+                    "description": "",
+                    "name": "hideFromMobile",
+                    "value": "false"
+                  },
+                  "highlight": {
+                    "description": "",
+                    "name": "highlight",
+                    "value": "false"
+                  },
+                  "iconUrl": {
+                    "description": "",
+                    "name": "iconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/ResumeActualitesCD37.svg"
+                  },
+                  "locale": {
+                    "description": "",
+                    "name": "locale",
+                    "value": "false"
+                  },
+                  "mobileIconUrl": {
+                    "description": "",
+                    "name": "mobileIconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/ResumeActualitesCD37.svg"
+                  },
+                  "printable": {
+                    "description": "",
+                    "name": "printable",
+                    "value": "false"
+                  },
+                  "secure": {
+                    "description": "",
+                    "name": "secure",
+                    "value": "false"
+                  },
+                  "showChrome": {
+                    "description": "",
+                    "name": "showChrome",
+                    "value": "false"
+                  }
+                },
+                "ratingsCount": 0,
+                "state": "PUBLISHED",
+                "title": "Derni\u00e8res actualit\u00e9s en Touraine",
+                "typeId": 7
+              },
+              {
+                "averageRating": 0,
+                "description": "Description du projet Touraine-eschool                                                                       ENT, D\u00e9partement, Touraine, Indre-et-Loire, acad\u00e9mie, Orl\u00e9ans, Tours, pr\u00e9sentation, information",
+                "favorite": false,
+                "fname": "accueil-clg37",
+                "id": 113,
+                "keywords": [],
+                "name": "Description Touraine E-School",
+                "parameters": {
+                  "alternate": {
+                    "description": "",
+                    "name": "alternate",
+                    "value": "false"
+                  },
+                  "blockImpersonation": {
+                    "description": "",
+                    "name": "blockImpersonation",
+                    "value": "false"
+                  },
+                  "disableDynamicTitle": {
+                    "description": "",
+                    "name": "disableDynamicTitle",
+                    "value": "true"
+                  },
+                  "editable": {
+                    "description": "",
+                    "name": "editable",
+                    "value": "false"
+                  },
+                  "hasAbout": {
+                    "description": "",
+                    "name": "hasAbout",
+                    "value": "false"
+                  },
+                  "hasHelp": {
+                    "description": "",
+                    "name": "hasHelp",
+                    "value": "false"
+                  },
+                  "hideFromDesktop": {
+                    "description": "",
+                    "name": "hideFromDesktop",
+                    "value": "false"
+                  },
+                  "hideFromMobile": {
+                    "description": "",
+                    "name": "hideFromMobile",
+                    "value": "false"
+                  },
+                  "highlight": {
+                    "description": "",
+                    "name": "highlight",
+                    "value": "false"
+                  },
+                  "iconUrl": {
+                    "description": "",
+                    "name": "iconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/accueil-clg37.svg"
+                  },
+                  "locale": {
+                    "description": "",
+                    "name": "locale",
+                    "value": "false"
+                  },
+                  "mobileIconUrl": {
+                    "description": "",
+                    "name": "mobileIconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/accueil-clg37.svg"
+                  },
+                  "printable": {
+                    "description": "",
+                    "name": "printable",
+                    "value": "false"
+                  },
+                  "secure": {
+                    "description": "",
+                    "name": "secure",
+                    "value": "false"
+                  },
+                  "showChrome": {
+                    "description": "",
+                    "name": "showChrome",
+                    "value": "true"
+                  }
+                },
+                "ratingsCount": 0,
+                "state": "PUBLISHED",
+                "title": "Description de Touraine E-School",
+                "typeId": 4
+              },
+              {
+                "averageRating": 0,
+                "description": "L'\u00e9ducation en Touraine, les actions du Conseil D\u00e9partemental d\u2019Indre-et-Loire                               informations, actions scolaires, actions \u00e9ducatives, actions sociales, \u00e9l\u00e8ves, parents",
+                "favorite": false,
+                "fname": "EducationTouraine",
+                "id": 60,
+                "keywords": [],
+                "name": "L'\u00e9ducation en Touraine",
+                "parameters": {
+                  "alternate": {
+                    "description": "",
+                    "name": "alternate",
+                    "value": "false"
+                  },
+                  "blockImpersonation": {
+                    "description": "",
+                    "name": "blockImpersonation",
+                    "value": "false"
+                  },
+                  "disableDynamicTitle": {
+                    "description": "",
+                    "name": "disableDynamicTitle",
+                    "value": "true"
+                  },
+                  "editable": {
+                    "description": "",
+                    "name": "editable",
+                    "value": "false"
+                  },
+                  "hasAbout": {
+                    "description": "",
+                    "name": "hasAbout",
+                    "value": "false"
+                  },
+                  "hasHelp": {
+                    "description": "",
+                    "name": "hasHelp",
+                    "value": "false"
+                  },
+                  "hideFromDesktop": {
+                    "description": "",
+                    "name": "hideFromDesktop",
+                    "value": "false"
+                  },
+                  "hideFromMobile": {
+                    "description": "",
+                    "name": "hideFromMobile",
+                    "value": "false"
+                  },
+                  "highlight": {
+                    "description": "",
+                    "name": "highlight",
+                    "value": "false"
+                  },
+                  "iconUrl": {
+                    "description": "",
+                    "name": "iconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/EducationTouraine.svg"
+                  },
+                  "mobileIconUrl": {
+                    "description": "",
+                    "name": "mobileIconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/EducationTouraine.svg"
+                  },
+                  "printable": {
+                    "description": "",
+                    "name": "printable",
+                    "value": "false"
+                  },
+                  "showChrome": {
+                    "description": "",
+                    "name": "showChrome",
+                    "value": "true"
+                  }
+                },
+                "ratingsCount": 0,
+                "state": "PUBLISHED",
+                "title": "L'\u00e9ducation en Touraine",
+                "typeId": 4
+              }
+            ],
+            "subcategories": []
+          },
+          {
+            "description": "Services collaboratifs",
+            "id": "local.32",
+            "name": "Espaces collaboratifs",
+            "portlets": [
+              {
+                "averageRating": 0,
+                "description": "Plateforme p\u00e9dagogique Moodle (cours en ligne, ressources, exercices, entra\u00eenement, ...)                              tests, quizz, documentation, \u00e9valuation",
+                "favorite": false,
+                "fname": "MoodleMu",
+                "id": 84,
+                "keywords": [],
+                "name": "Espaces Moodle",
+                "parameters": {
+                  "alternate": {
+                    "description": "",
+                    "name": "alternate",
+                    "value": "false"
+                  },
+                  "alternativeMaximizedLink": {
+                    "description": "",
+                    "name": "alternativeMaximizedLink",
+                    "value": "/moodle/my"
+                  },
+                  "blockImpersonation": {
+                    "description": "",
+                    "name": "blockImpersonation",
+                    "value": "true"
+                  },
+                  "editable": {
+                    "description": "",
+                    "name": "editable",
+                    "value": "false"
+                  },
+                  "hasAbout": {
+                    "description": "",
+                    "name": "hasAbout",
+                    "value": "false"
+                  },
+                  "hasHelp": {
+                    "description": "",
+                    "name": "hasHelp",
+                    "value": "false"
+                  },
+                  "hideFromDesktop": {
+                    "description": "",
+                    "name": "hideFromDesktop",
+                    "value": "false"
+                  },
+                  "hideFromMobile": {
+                    "description": "",
+                    "name": "hideFromMobile",
+                    "value": "false"
+                  },
+                  "highlight": {
+                    "description": "",
+                    "name": "highlight",
+                    "value": "false"
+                  },
+                  "iconUrl": {
+                    "description": "",
+                    "name": "iconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/MoodleMu.svg"
+                  },
+                  "locale": {
+                    "description": "",
+                    "name": "locale",
+                    "value": "false"
+                  },
+                  "mobileIconUrl": {
+                    "description": "",
+                    "name": "mobileIconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/MoodleMu.svg"
+                  },
+                  "printable": {
+                    "description": "",
+                    "name": "printable",
+                    "value": "false"
+                  },
+                  "secure": {
+                    "description": "",
+                    "name": "secure",
+                    "value": "false"
+                  },
+                  "showChrome": {
+                    "description": "",
+                    "name": "showChrome",
+                    "value": "true"
+                  }
+                },
+                "ratingsCount": 0,
+                "state": "PUBLISHED",
+                "title": "Espaces Moodle",
+                "typeId": 6
+              },
+              {
+                "averageRating": 0,
+                "description": "Acc\u00e8s aux espaces de fichiers p\u00e9dagogiques de l'\u00e9tablissement                                                stocker, fichiers, r\u00e9pertoires, partage, partager, consultation, consulter",
+                "favorite": true,
+                "fname": "esup-filemanager",
+                "id": 116,
+                "keywords": [],
+                "name": "Espaces de stockage",
+                "parameters": {
+                  "alternate": {
+                    "description": "",
+                    "name": "alternate",
+                    "value": "false"
+                  },
+                  "blockImpersonation": {
+                    "description": "",
+                    "name": "blockImpersonation",
+                    "value": "false"
+                  },
+                  "disableDynamicTitle": {
+                    "description": "",
+                    "name": "disableDynamicTitle",
+                    "value": "true"
+                  },
+                  "editable": {
+                    "description": "",
+                    "name": "editable",
+                    "value": "false"
+                  },
+                  "hasAbout": {
+                    "description": "",
+                    "name": "hasAbout",
+                    "value": "false"
+                  },
+                  "hasHelp": {
+                    "description": "",
+                    "name": "hasHelp",
+                    "value": "false"
+                  },
+                  "hideFromDesktop": {
+                    "description": "",
+                    "name": "hideFromDesktop",
+                    "value": "false"
+                  },
+                  "hideFromMobile": {
+                    "description": "",
+                    "name": "hideFromMobile",
+                    "value": "false"
+                  },
+                  "highlight": {
+                    "description": "",
+                    "name": "highlight",
+                    "value": "false"
+                  },
+                  "iconUrl": {
+                    "description": "",
+                    "name": "iconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/esup-filemanager.svg"
+                  },
+                  "locale": {
+                    "description": "",
+                    "name": "locale",
+                    "value": "false"
+                  },
+                  "mobileIconUrl": {
+                    "description": "",
+                    "name": "mobileIconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/esup-filemanager.svg"
+                  },
+                  "printable": {
+                    "description": "",
+                    "name": "printable",
+                    "value": "false"
+                  },
+                  "secure": {
+                    "description": "",
+                    "name": "secure",
+                    "value": "false"
+                  },
+                  "showChrome": {
+                    "description": "",
+                    "name": "showChrome",
+                    "value": "true"
+                  }
+                },
+                "ratingsCount": 0,
+                "state": "PUBLISHED",
+                "title": "Espaces de stockage",
+                "typeId": 7
+              },
+              {
+                "averageRating": 0,
+                "description": "Les listes de diffusion de l'\u00e9tablissement                                                                     courriel, courrier, \u00e9lectronique, mail, diffuser, poster",
+                "favorite": false,
+                "fname": "ListesDiffusion",
+                "id": 80,
+                "keywords": [],
+                "name": "Listes de diffusion",
+                "parameters": {
+                  "alternate": {
+                    "description": "",
+                    "name": "alternate",
+                    "value": "false"
+                  },
+                  "blockImpersonation": {
+                    "description": "",
+                    "name": "blockImpersonation",
+                    "value": "false"
+                  },
+                  "disableDynamicTitle": {
+                    "description": "",
+                    "name": "disableDynamicTitle",
+                    "value": "true"
+                  },
+                  "editable": {
+                    "description": "",
+                    "name": "editable",
+                    "value": "false"
+                  },
+                  "hasAbout": {
+                    "description": "",
+                    "name": "hasAbout",
+                    "value": "false"
+                  },
+                  "hasHelp": {
+                    "description": "",
+                    "name": "hasHelp",
+                    "value": "false"
+                  },
+                  "hideFromDesktop": {
+                    "description": "",
+                    "name": "hideFromDesktop",
+                    "value": "false"
+                  },
+                  "hideFromMobile": {
+                    "description": "",
+                    "name": "hideFromMobile",
+                    "value": "false"
+                  },
+                  "highlight": {
+                    "description": "",
+                    "name": "highlight",
+                    "value": "false"
+                  },
+                  "iconUrl": {
+                    "description": "",
+                    "name": "iconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/ListesDiffusion.svg"
+                  },
+                  "locale": {
+                    "description": "",
+                    "name": "locale",
+                    "value": "false"
+                  },
+                  "mobileIconUrl": {
+                    "description": "",
+                    "name": "mobileIconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/ListesDiffusion.svg"
+                  },
+                  "printable": {
+                    "description": "",
+                    "name": "printable",
+                    "value": "false"
+                  },
+                  "secure": {
+                    "description": "",
+                    "name": "secure",
+                    "value": "false"
+                  },
+                  "showChrome": {
+                    "description": "",
+                    "name": "showChrome",
+                    "value": "true"
+                  }
+                },
+                "ratingsCount": 0,
+                "state": "PUBLISHED",
+                "title": "Listes de diffusion",
+                "typeId": 7
+              },
+              {
+                "averageRating": 0,
+                "description": "Plate-forme OAE du GIP RECIA, outil collaboratif et de r\u00e9seau social                                         projets, partage, groupes, collaboratif, stockage, ESUP, \u00e9criture collaborative, vid\u00e9os, sons, documents, images, versions, travail collaboratif",
+                "favorite": false,
+                "fname": "OAE_RECIA",
+                "id": 109,
+                "keywords": [],
+                "name": "R\u00e9seau social OAE",
+                "parameters": {
+                  "alternate": {
+                    "description": "",
+                    "name": "alternate",
+                    "value": "false"
+                  },
+                  "alternativeMaximizedLink": {
+                    "description": "",
+                    "name": "alternativeMaximizedLink",
+                    "value": "/portail/api/ExternalURLStats?fname=OAE_RECIA&service=https://oae.giprecia.fr"
+                  },
+                  "blockImpersonation": {
+                    "description": "",
+                    "name": "blockImpersonation",
+                    "value": "true"
+                  },
+                  "editable": {
+                    "description": "",
+                    "name": "editable",
+                    "value": "false"
+                  },
+                  "hasAbout": {
+                    "description": "",
+                    "name": "hasAbout",
+                    "value": "false"
+                  },
+                  "hasHelp": {
+                    "description": "",
+                    "name": "hasHelp",
+                    "value": "false"
+                  },
+                  "hideFromDesktop": {
+                    "description": "",
+                    "name": "hideFromDesktop",
+                    "value": "false"
+                  },
+                  "hideFromMobile": {
+                    "description": "",
+                    "name": "hideFromMobile",
+                    "value": "false"
+                  },
+                  "highlight": {
+                    "description": "",
+                    "name": "highlight",
+                    "value": "false"
+                  },
+                  "iconUrl": {
+                    "description": "",
+                    "name": "iconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/AccesOAE_RECIA.svg"
+                  },
+                  "mobileIconUrl": {
+                    "description": "",
+                    "name": "mobileIconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/AccesOAE_RECIA.svg"
+                  },
+                  "printable": {
+                    "description": "",
+                    "name": "printable",
+                    "value": "false"
+                  },
+                  "showChrome": {
+                    "description": "",
+                    "name": "showChrome",
+                    "value": "true"
+                  }
+                },
+                "ratingsCount": 0,
+                "state": "PUBLISHED",
+                "title": "OAE",
+                "typeId": 6
+              },
+              {
+                "averageRating": 0,
+                "description": "Application ownCloud du GIP RECIA                                                                              stockage, partage, r\u00e9pertoires, fichiers, multim\u00e9dia, vid\u00e9os, sons, images, documents, versions, nextcloud",
+                "favorite": false,
+                "fname": "OwnCloud_RECIA",
+                "id": 86,
+                "keywords": [],
+                "name": "ownCloud du GIP RECIA",
+                "parameters": {
+                  "alternate": {
+                    "description": "",
+                    "name": "alternate",
+                    "value": "false"
+                  },
+                  "alternativeMaximizedLink": {
+                    "description": "",
+                    "name": "alternativeMaximizedLink",
+                    "value": "/portail/api/ExternalURLStats?fname=Owncloud_RECIA&service=https://owncloud.recia.fr/index.php?app=user_cas"
+                  },
+                  "blockImpersonation": {
+                    "description": "",
+                    "name": "blockImpersonation",
+                    "value": "true"
+                  },
+                  "editable": {
+                    "description": "",
+                    "name": "editable",
+                    "value": "false"
+                  },
+                  "hasAbout": {
+                    "description": "",
+                    "name": "hasAbout",
+                    "value": "false"
+                  },
+                  "hasHelp": {
+                    "description": "",
+                    "name": "hasHelp",
+                    "value": "false"
+                  },
+                  "hideFromDesktop": {
+                    "description": "",
+                    "name": "hideFromDesktop",
+                    "value": "false"
+                  },
+                  "hideFromMobile": {
+                    "description": "",
+                    "name": "hideFromMobile",
+                    "value": "false"
+                  },
+                  "highlight": {
+                    "description": "",
+                    "name": "highlight",
+                    "value": "false"
+                  },
+                  "iconUrl": {
+                    "description": "",
+                    "name": "iconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/OwnCloud_RECIA.svg"
+                  },
+                  "locale": {
+                    "description": "",
+                    "name": "locale",
+                    "value": "false"
+                  },
+                  "mobileIconUrl": {
+                    "description": "",
+                    "name": "mobileIconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/OwnCloud_RECIA.svg"
+                  },
+                  "printable": {
+                    "description": "",
+                    "name": "printable",
+                    "value": "false"
+                  },
+                  "secure": {
+                    "description": "",
+                    "name": "secure",
+                    "value": "false"
+                  }
+                },
+                "ratingsCount": 0,
+                "state": "PUBLISHED",
+                "title": "ownCloud",
+                "typeId": 6
+              }
+            ],
+            "subcategories": []
+          },
+          {
+            "description": "Services d'information",
+            "id": "local.15",
+            "name": "Information",
+            "portlets": [
+              {
+                "averageRating": 0,
+                "description": "Recherche de contenu dans le portail",
+                "favorite": false,
+                "fname": "search",
+                "id": 29,
+                "keywords": [],
+                "name": "Recherche",
+                "parameters": {
+                  "disableDynamicTitle": {
+                    "description": "",
+                    "name": "disableDynamicTitle",
+                    "value": "true"
+                  },
+                  "iconUrl": {
+                    "description": "",
+                    "name": "iconUrl",
+                    "value": "https://ent.recia.fr/ResourceServingWebapp/rs/tango/0.8.90/32x32/actions/system-search.png"
+                  },
+                  "mobileIconUrl": {
+                    "description": "",
+                    "name": "mobileIconUrl",
+                    "value": "/portail/media/skins/icons/mobile/search.png"
+                  }
+                },
+                "ratingsCount": 0,
+                "state": "PUBLISHED",
+                "title": "Recherche",
+                "typeId": 7
+              },
+              {
+                "averageRating": 0,
+                "description": "R\u00e9pertoire de contacts",
+                "favorite": false,
+                "fname": "directory",
+                "id": 5,
+                "keywords": [],
+                "name": "R\u00e9pertoire",
+                "parameters": {
+                  "disableDynamicTitle": {
+                    "description": "",
+                    "name": "disableDynamicTitle",
+                    "value": "true"
+                  },
+                  "iconUrl": {
+                    "description": "",
+                    "name": "iconUrl",
+                    "value": "https://ent.recia.fr/ResourceServingWebapp/rs/tango/0.8.90/32x32/mimetypes/x-office-address-book.png"
+                  },
+                  "mobileIconUrl": {
+                    "description": "",
+                    "name": "mobileIconUrl",
+                    "value": "/portail/media/skins/icons/mobile/directory.png"
+                  }
+                },
+                "ratingsCount": 0,
+                "state": "PUBLISHED",
+                "title": "R\u00e9pertoire",
+                "typeId": 7
+              }
+            ],
+            "subcategories": []
+          },
+          {
+            "description": "Services li\u00e9s \u00e0 la mobilit\u00e9",
+            "id": "local.33",
+            "name": "Mobilit\u00e9",
+            "portlets": [],
+            "subcategories": []
+          },
+          {
+            "description": "Services li\u00e9s \u00e0 l'orientation",
+            "id": "local.34",
+            "name": "Parcours - orientation",
+            "portlets": [
+              {
+                "averageRating": 0,
+                "description": "Outil de suivi et d'\u00e9valuation de comp\u00e9tences pour la formation professionnelle                              CANOPE, bilan",
+                "favorite": false,
+                "fname": "CPRO",
+                "id": 139,
+                "keywords": [],
+                "name": "Cerise Pro",
+                "parameters": {
+                  "alternate": {
+                    "description": "",
+                    "name": "alternate",
+                    "value": "false"
+                  },
+                  "alternativeMaximizedLink": {
+                    "description": "",
+                    "name": "alternativeMaximizedLink",
+                    "value": "/portail/api/ExternalURLStats?fname=CPRO&service=/esco-apps-redirector/index.php?appli=CERISEPRO"
+                  },
+                  "blockImpersonation": {
+                    "description": "",
+                    "name": "blockImpersonation",
+                    "value": "true"
+                  },
+                  "editable": {
+                    "description": "",
+                    "name": "editable",
+                    "value": "false"
+                  },
+                  "hasAbout": {
+                    "description": "",
+                    "name": "hasAbout",
+                    "value": "false"
+                  },
+                  "hasHelp": {
+                    "description": "",
+                    "name": "hasHelp",
+                    "value": "false"
+                  },
+                  "hideFromDesktop": {
+                    "description": "",
+                    "name": "hideFromDesktop",
+                    "value": "false"
+                  },
+                  "hideFromMobile": {
+                    "description": "",
+                    "name": "hideFromMobile",
+                    "value": "false"
+                  },
+                  "highlight": {
+                    "description": "",
+                    "name": "highlight",
+                    "value": "false"
+                  },
+                  "iconUrl": {
+                    "description": "",
+                    "name": "iconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/CPRO.svg"
+                  },
+                  "locale": {
+                    "description": "",
+                    "name": "locale",
+                    "value": "false"
+                  },
+                  "mobileIconUrl": {
+                    "description": "",
+                    "name": "mobileIconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/CPRO.svg"
+                  },
+                  "printable": {
+                    "description": "",
+                    "name": "printable",
+                    "value": "false"
+                  },
+                  "secure": {
+                    "description": "",
+                    "name": "secure",
+                    "value": "false"
+                  },
+                  "showChrome": {
+                    "description": "",
+                    "name": "showChrome",
+                    "value": "true"
+                  }
+                },
+                "ratingsCount": 0,
+                "state": "PUBLISHED",
+                "title": "Cerise Pro",
+                "typeId": 6
+              },
+              {
+                "averageRating": 0,
+                "description": "Outil de suivi et d'\u00e9valuation de comp\u00e9tences pour la formation professionnelle des STI                      CANOPE, bilan",
+                "favorite": false,
+                "fname": "CPRO-STI",
+                "id": 138,
+                "keywords": [],
+                "name": "Cerise Pro-STI",
+                "parameters": {
+                  "alternate": {
+                    "description": "",
+                    "name": "alternate",
+                    "value": "false"
+                  },
+                  "alternativeMaximizedLink": {
+                    "description": "",
+                    "name": "alternativeMaximizedLink",
+                    "value": "/portail/api/ExternalURLStats?fname=CPRO-STI&service=/esco-apps-redirector/index.php?appli=CERISEPROSTI"
+                  },
+                  "blockImpersonation": {
+                    "description": "",
+                    "name": "blockImpersonation",
+                    "value": "true"
+                  },
+                  "editable": {
+                    "description": "",
+                    "name": "editable",
+                    "value": "false"
+                  },
+                  "hasAbout": {
+                    "description": "",
+                    "name": "hasAbout",
+                    "value": "false"
+                  },
+                  "hasHelp": {
+                    "description": "",
+                    "name": "hasHelp",
+                    "value": "false"
+                  },
+                  "hideFromDesktop": {
+                    "description": "",
+                    "name": "hideFromDesktop",
+                    "value": "false"
+                  },
+                  "hideFromMobile": {
+                    "description": "",
+                    "name": "hideFromMobile",
+                    "value": "false"
+                  },
+                  "highlight": {
+                    "description": "",
+                    "name": "highlight",
+                    "value": "false"
+                  },
+                  "iconUrl": {
+                    "description": "",
+                    "name": "iconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/CPRO.svg"
+                  },
+                  "locale": {
+                    "description": "",
+                    "name": "locale",
+                    "value": "false"
+                  },
+                  "mobileIconUrl": {
+                    "description": "",
+                    "name": "mobileIconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/CPRO.svg"
+                  },
+                  "printable": {
+                    "description": "",
+                    "name": "printable",
+                    "value": "false"
+                  },
+                  "secure": {
+                    "description": "",
+                    "name": "secure",
+                    "value": "false"
+                  },
+                  "showChrome": {
+                    "description": "",
+                    "name": "showChrome",
+                    "value": "true"
+                  }
+                },
+                "ratingsCount": 0,
+                "state": "PUBLISHED",
+                "title": "Cerise Pro-STI",
+                "typeId": 6
+              },
+              {
+                "averageRating": 0,
+                "description": "Folios de l'ONISEP                                                                                             apprentissage, comp\u00e9tences, acquisition, parcours, suivi, Onisep, acad\u00e9mie, Orl\u00e9ans-Tours, rectorat",
+                "favorite": false,
+                "fname": "Folios",
+                "id": 68,
+                "keywords": [],
+                "name": "Folios",
+                "parameters": {
+                  "alternate": {
+                    "description": "",
+                    "name": "alternate",
+                    "value": "false"
+                  },
+                  "alternativeMaximizedLink": {
+                    "description": "",
+                    "name": "alternativeMaximizedLink",
+                    "value": "/portail/api/ExternalURLStats?fname=Folios&service=/esco-apps-redirector/index.php?appli=FOLIOS"
+                  },
+                  "blockImpersonation": {
+                    "description": "",
+                    "name": "blockImpersonation",
+                    "value": "true"
+                  },
+                  "disableDynamicTitle": {
+                    "description": "",
+                    "name": "disableDynamicTitle",
+                    "value": "true"
+                  },
+                  "editable": {
+                    "description": "",
+                    "name": "editable",
+                    "value": "false"
+                  },
+                  "hasAbout": {
+                    "description": "",
+                    "name": "hasAbout",
+                    "value": "false"
+                  },
+                  "hasHelp": {
+                    "description": "",
+                    "name": "hasHelp",
+                    "value": "false"
+                  },
+                  "hideFromDesktop": {
+                    "description": "",
+                    "name": "hideFromDesktop",
+                    "value": "false"
+                  },
+                  "hideFromMobile": {
+                    "description": "",
+                    "name": "hideFromMobile",
+                    "value": "false"
+                  },
+                  "highlight": {
+                    "description": "",
+                    "name": "highlight",
+                    "value": "false"
+                  },
+                  "iconUrl": {
+                    "description": "",
+                    "name": "iconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/Folios.svg"
+                  },
+                  "mobileIconUrl": {
+                    "description": "",
+                    "name": "mobileIconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/Folios.svg"
+                  },
+                  "printable": {
+                    "description": "",
+                    "name": "printable",
+                    "value": "false"
+                  },
+                  "showChrome": {
+                    "description": "",
+                    "name": "showChrome",
+                    "value": "true"
+                  }
+                },
+                "ratingsCount": 0,
+                "state": "PUBLISHED",
+                "title": "Folios",
+                "typeId": 4
+              },
+              {
+                "averageRating": 0,
+                "description": "Fil d'informations provenant du portail \u00c9toile                                                                 R\u00e9gion Centre-Val de Loire, Etoile, Onisep, poursuite, \u00e9tudes, bac, post-bac, baccalaur\u00e9at, universit\u00e9s, \u00e9coles, emploi",
+                "favorite": false,
+                "fname": "infosEtoile",
+                "id": 118,
+                "keywords": [],
+                "name": "Informations du portail \u00c9toile",
+                "parameters": {
+                  "alternate": {
+                    "description": "",
+                    "name": "alternate",
+                    "value": "false"
+                  },
+                  "blockImpersonation": {
+                    "description": "",
+                    "name": "blockImpersonation",
+                    "value": "false"
+                  },
+                  "disableDynamicTitle": {
+                    "description": "",
+                    "name": "disableDynamicTitle",
+                    "value": "true"
+                  },
+                  "editable": {
+                    "description": "",
+                    "name": "editable",
+                    "value": "false"
+                  },
+                  "hasAbout": {
+                    "description": "",
+                    "name": "hasAbout",
+                    "value": "false"
+                  },
+                  "hasHelp": {
+                    "description": "",
+                    "name": "hasHelp",
+                    "value": "false"
+                  },
+                  "hideFromDesktop": {
+                    "description": "",
+                    "name": "hideFromDesktop",
+                    "value": "false"
+                  },
+                  "hideFromMobile": {
+                    "description": "",
+                    "name": "hideFromMobile",
+                    "value": "false"
+                  },
+                  "highlight": {
+                    "description": "",
+                    "name": "highlight",
+                    "value": "false"
+                  },
+                  "iconUrl": {
+                    "description": "",
+                    "name": "iconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/infosEtoile.svg"
+                  },
+                  "locale": {
+                    "description": "",
+                    "name": "locale",
+                    "value": "false"
+                  },
+                  "mobileIconUrl": {
+                    "description": "",
+                    "name": "mobileIconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/infosEtoile.svg"
+                  },
+                  "printable": {
+                    "description": "",
+                    "name": "printable",
+                    "value": "false"
+                  },
+                  "secure": {
+                    "description": "",
+                    "name": "secure",
+                    "value": "false"
+                  },
+                  "showChrome": {
+                    "description": "",
+                    "name": "showChrome",
+                    "value": "true"
+                  }
+                },
+                "ratingsCount": 0,
+                "state": "PUBLISHED",
+                "title": "Informations du portail \u00c9toile",
+                "typeId": 7
+              },
+              {
+                "averageRating": 0,
+                "description": "Application acad\u00e9mique de gestion du B2I (acc\u00e8s r\u00e9serv\u00e9 aux personnels de l'\u00c9ducation Nationale)",
+                "favorite": false,
+                "fname": "OBII",
+                "id": 85,
+                "keywords": [],
+                "name": "OBII pour les personnels",
+                "parameters": {
+                  "alternate": {
+                    "description": "",
+                    "name": "alternate",
+                    "value": "false"
+                  },
+                  "alternativeMaximizedLink": {
+                    "description": "",
+                    "name": "alternativeMaximizedLink",
+                    "value": "/portail/api/ExternalURLStats?fname=OBII&service=/esco-apps-redirector/index.php?appli=OBII"
+                  },
+                  "blockImpersonation": {
+                    "description": "",
+                    "name": "blockImpersonation",
+                    "value": "true"
+                  },
+                  "editable": {
+                    "description": "",
+                    "name": "editable",
+                    "value": "false"
+                  },
+                  "hasAbout": {
+                    "description": "",
+                    "name": "hasAbout",
+                    "value": "false"
+                  },
+                  "hasHelp": {
+                    "description": "",
+                    "name": "hasHelp",
+                    "value": "false"
+                  },
+                  "hideFromDesktop": {
+                    "description": "",
+                    "name": "hideFromDesktop",
+                    "value": "false"
+                  },
+                  "hideFromMobile": {
+                    "description": "",
+                    "name": "hideFromMobile",
+                    "value": "false"
+                  },
+                  "highlight": {
+                    "description": "",
+                    "name": "highlight",
+                    "value": "false"
+                  },
+                  "iconUrl": {
+                    "description": "",
+                    "name": "iconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/OBII.svg"
+                  },
+                  "locale": {
+                    "description": "",
+                    "name": "locale",
+                    "value": "false"
+                  },
+                  "mobileIconUrl": {
+                    "description": "",
+                    "name": "mobileIconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/OBII.svg"
+                  },
+                  "printable": {
+                    "description": "",
+                    "name": "printable",
+                    "value": "false"
+                  },
+                  "secure": {
+                    "description": "",
+                    "name": "secure",
+                    "value": "false"
+                  },
+                  "showChrome": {
+                    "description": "",
+                    "name": "showChrome",
+                    "value": "true"
+                  }
+                },
+                "ratingsCount": 0,
+                "state": "PUBLISHED",
+                "title": "OBII",
+                "typeId": 6
+              },
+              {
+                "averageRating": 0,
+                "description": "Ressources pour l'orientation des \u00e9l\u00e8ves                                                                     R\u00e9gion Centre-Val de Loire, \u00c9toile, Etoile, Onisep, poursuite, \u00e9tudes, post-bac, universit\u00e9s, acad\u00e9mie, acad\u00e9mique, emplois, apprentissages",
+                "favorite": false,
+                "fname": "RessourcesOrientationLycees",
+                "id": 92,
+                "keywords": [],
+                "name": "Ressources d'orientation",
+                "parameters": {
+                  "alternate": {
+                    "description": "",
+                    "name": "alternate",
+                    "value": "false"
+                  },
+                  "blockImpersonation": {
+                    "description": "",
+                    "name": "blockImpersonation",
+                    "value": "false"
+                  },
+                  "disableDynamicTitle": {
+                    "description": "",
+                    "name": "disableDynamicTitle",
+                    "value": "true"
+                  },
+                  "editable": {
+                    "description": "",
+                    "name": "editable",
+                    "value": "false"
+                  },
+                  "hasAbout": {
+                    "description": "",
+                    "name": "hasAbout",
+                    "value": "false"
+                  },
+                  "hasHelp": {
+                    "description": "",
+                    "name": "hasHelp",
+                    "value": "false"
+                  },
+                  "hideFromDesktop": {
+                    "description": "",
+                    "name": "hideFromDesktop",
+                    "value": "false"
+                  },
+                  "hideFromMobile": {
+                    "description": "",
+                    "name": "hideFromMobile",
+                    "value": "false"
+                  },
+                  "highlight": {
+                    "description": "",
+                    "name": "highlight",
+                    "value": "false"
+                  },
+                  "iconUrl": {
+                    "description": "",
+                    "name": "iconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/RessourcesOrientationLycees.svg"
+                  },
+                  "mobileIconUrl": {
+                    "description": "",
+                    "name": "mobileIconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/RessourcesOrientationLycees.svg"
+                  },
+                  "printable": {
+                    "description": "",
+                    "name": "printable",
+                    "value": "false"
+                  },
+                  "showChrome": {
+                    "description": "",
+                    "name": "showChrome",
+                    "value": "true"
+                  }
+                },
+                "ratingsCount": 0,
+                "state": "PUBLISHED",
+                "title": "Orientation",
+                "typeId": 4
+              },
+              {
+                "averageRating": 0,
+                "description": "Gestionnaire de comp\u00e9tences SACoche de Sesamath                                                              apprentissage, acquisition, parcours, suivi, \u00e9volution",
+                "favorite": false,
+                "fname": "SACoche",
+                "id": 97,
+                "keywords": [],
+                "name": "Suivi d'acquisition de comp\u00e9tences",
+                "parameters": {
+                  "alternate": {
+                    "description": "",
+                    "name": "alternate",
+                    "value": "false"
+                  },
+                  "alternativeMaximizedLink": {
+                    "description": "",
+                    "name": "alternativeMaximizedLink",
+                    "value": "/portail/api/ExternalURLStats?fname=SACoche&service=/esco-apps-redirector/index.php?appli=SACOCHE"
+                  },
+                  "blockImpersonation": {
+                    "description": "",
+                    "name": "blockImpersonation",
+                    "value": "true"
+                  },
+                  "editable": {
+                    "description": "",
+                    "name": "editable",
+                    "value": "false"
+                  },
+                  "hasAbout": {
+                    "description": "",
+                    "name": "hasAbout",
+                    "value": "false"
+                  },
+                  "hasHelp": {
+                    "description": "",
+                    "name": "hasHelp",
+                    "value": "false"
+                  },
+                  "hideFromDesktop": {
+                    "description": "",
+                    "name": "hideFromDesktop",
+                    "value": "false"
+                  },
+                  "hideFromMobile": {
+                    "description": "",
+                    "name": "hideFromMobile",
+                    "value": "false"
+                  },
+                  "highlight": {
+                    "description": "",
+                    "name": "highlight",
+                    "value": "false"
+                  },
+                  "iconUrl": {
+                    "description": "",
+                    "name": "iconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/SACoche.svg"
+                  },
+                  "locale": {
+                    "description": "",
+                    "name": "locale",
+                    "value": "false"
+                  },
+                  "mobileIconUrl": {
+                    "description": "",
+                    "name": "mobileIconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/SACoche.svg"
+                  },
+                  "printable": {
+                    "description": "",
+                    "name": "printable",
+                    "value": "false"
+                  },
+                  "secure": {
+                    "description": "",
+                    "name": "secure",
+                    "value": "false"
+                  },
+                  "showChrome": {
+                    "description": "",
+                    "name": "showChrome",
+                    "value": "true"
+                  }
+                },
+                "ratingsCount": 0,
+                "state": "PUBLISHED",
+                "title": "Suivi d'acquisition de comp\u00e9tences",
+                "typeId": 6
+              }
+            ],
+            "subcategories": []
+          },
+          {
+            "description": "Services li\u00e9s \u00e0 la p\u00e9dagogie et \u00e0 l'apprentissage",
+            "id": "local.35",
+            "name": "P\u00e9dagogie - apprentissage",
+            "portlets": [
+              {
+                "averageRating": 0,
+                "description": "Acc\u00e8s aux ressources du CDI                                                                                  centre de documentation, information, biblioth\u00e8que, documentation, livres, scolaires, emprunter, multi-m\u00e9dia, ressources, num\u00e9riques, e-sidoc",
+                "favorite": false,
+                "fname": "MonCDIPLCourier",
+                "id": 83,
+                "keywords": [],
+                "name": "CDI du coll\u00e8ge",
+                "parameters": {
+                  "alternate": {
+                    "description": "",
+                    "name": "alternate",
+                    "value": "false"
+                  },
+                  "alternativeMaximizedLink": {
+                    "description": "",
+                    "name": "alternativeMaximizedLink",
+                    "value": "/portail/api/ExternalURLStats?fname=ESIDOC&service=https://0379998s.esidoc.fr/home/"
+                  },
+                  "blockImpersonation": {
+                    "description": "",
+                    "name": "blockImpersonation",
+                    "value": "false"
+                  },
+                  "disableDynamicTitle": {
+                    "description": "",
+                    "name": "disableDynamicTitle",
+                    "value": "true"
+                  },
+                  "editable": {
+                    "description": "",
+                    "name": "editable",
+                    "value": "false"
+                  },
+                  "hasAbout": {
+                    "description": "",
+                    "name": "hasAbout",
+                    "value": "false"
+                  },
+                  "hasHelp": {
+                    "description": "",
+                    "name": "hasHelp",
+                    "value": "false"
+                  },
+                  "hideFromDesktop": {
+                    "description": "",
+                    "name": "hideFromDesktop",
+                    "value": "false"
+                  },
+                  "hideFromMobile": {
+                    "description": "",
+                    "name": "hideFromMobile",
+                    "value": "false"
+                  },
+                  "highlight": {
+                    "description": "",
+                    "name": "highlight",
+                    "value": "false"
+                  },
+                  "iconUrl": {
+                    "description": "",
+                    "name": "iconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/MonCDIPLCourier.svg"
+                  },
+                  "mobileIconUrl": {
+                    "description": "",
+                    "name": "mobileIconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/MonCDIPLCourier.svg"
+                  },
+                  "printable": {
+                    "description": "",
+                    "name": "printable",
+                    "value": "false"
+                  },
+                  "showChrome": {
+                    "description": "",
+                    "name": "showChrome",
+                    "value": "true"
+                  }
+                },
+                "ratingsCount": 0,
+                "state": "PUBLISHED",
+                "title": "CDI du coll\u00e8ge",
+                "typeId": 4
+              },
+              {
+                "averageRating": 0,
+                "description": "Cahier de texte num\u00e9rique                                                                                    devoirs, s\u00e9ances, emplois du temps, s\u00e9quences, mati\u00e8res, cours, travail \u00e0 faire, devoirs \u00e0 faire, suivi",
+                "favorite": false,
+                "fname": "CahierTexte",
+                "id": 49,
+                "keywords": [],
+                "name": "Cahier de texte",
+                "parameters": {
+                  "alternate": {
+                    "description": "",
+                    "name": "alternate",
+                    "value": "false"
+                  },
+                  "blockImpersonation": {
+                    "description": "",
+                    "name": "blockImpersonation",
+                    "value": "true"
+                  },
+                  "editable": {
+                    "description": "",
+                    "name": "editable",
+                    "value": "false"
+                  },
+                  "hasAbout": {
+                    "description": "",
+                    "name": "hasAbout",
+                    "value": "false"
+                  },
+                  "hasHelp": {
+                    "description": "",
+                    "name": "hasHelp",
+                    "value": "false"
+                  },
+                  "hideFromDesktop": {
+                    "description": "",
+                    "name": "hideFromDesktop",
+                    "value": "false"
+                  },
+                  "hideFromMobile": {
+                    "description": "",
+                    "name": "hideFromMobile",
+                    "value": "false"
+                  },
+                  "highlight": {
+                    "description": "",
+                    "name": "highlight",
+                    "value": "false"
+                  },
+                  "iconUrl": {
+                    "description": "",
+                    "name": "iconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/CahierTexte.svg"
+                  },
+                  "locale": {
+                    "description": "",
+                    "name": "locale",
+                    "value": "false"
+                  },
+                  "mobileIconUrl": {
+                    "description": "",
+                    "name": "mobileIconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/CahierTexte.svg"
+                  },
+                  "printable": {
+                    "description": "",
+                    "name": "printable",
+                    "value": "false"
+                  },
+                  "secure": {
+                    "description": "",
+                    "name": "secure",
+                    "value": "false"
+                  },
+                  "showChrome": {
+                    "description": "",
+                    "name": "showChrome",
+                    "value": "true"
+                  }
+                },
+                "ratingsCount": 0,
+                "state": "PUBLISHED",
+                "title": "Cahier de texte",
+                "typeId": 6
+              },
+              {
+                "averageRating": 0,
+                "description": "Outil de suivi et d'\u00e9valuation de comp\u00e9tences pour la formation professionnelle                              CANOPE, bilan",
+                "favorite": false,
+                "fname": "CPRO",
+                "id": 139,
+                "keywords": [],
+                "name": "Cerise Pro",
+                "parameters": {
+                  "alternate": {
+                    "description": "",
+                    "name": "alternate",
+                    "value": "false"
+                  },
+                  "alternativeMaximizedLink": {
+                    "description": "",
+                    "name": "alternativeMaximizedLink",
+                    "value": "/portail/api/ExternalURLStats?fname=CPRO&service=/esco-apps-redirector/index.php?appli=CERISEPRO"
+                  },
+                  "blockImpersonation": {
+                    "description": "",
+                    "name": "blockImpersonation",
+                    "value": "true"
+                  },
+                  "editable": {
+                    "description": "",
+                    "name": "editable",
+                    "value": "false"
+                  },
+                  "hasAbout": {
+                    "description": "",
+                    "name": "hasAbout",
+                    "value": "false"
+                  },
+                  "hasHelp": {
+                    "description": "",
+                    "name": "hasHelp",
+                    "value": "false"
+                  },
+                  "hideFromDesktop": {
+                    "description": "",
+                    "name": "hideFromDesktop",
+                    "value": "false"
+                  },
+                  "hideFromMobile": {
+                    "description": "",
+                    "name": "hideFromMobile",
+                    "value": "false"
+                  },
+                  "highlight": {
+                    "description": "",
+                    "name": "highlight",
+                    "value": "false"
+                  },
+                  "iconUrl": {
+                    "description": "",
+                    "name": "iconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/CPRO.svg"
+                  },
+                  "locale": {
+                    "description": "",
+                    "name": "locale",
+                    "value": "false"
+                  },
+                  "mobileIconUrl": {
+                    "description": "",
+                    "name": "mobileIconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/CPRO.svg"
+                  },
+                  "printable": {
+                    "description": "",
+                    "name": "printable",
+                    "value": "false"
+                  },
+                  "secure": {
+                    "description": "",
+                    "name": "secure",
+                    "value": "false"
+                  },
+                  "showChrome": {
+                    "description": "",
+                    "name": "showChrome",
+                    "value": "true"
+                  }
+                },
+                "ratingsCount": 0,
+                "state": "PUBLISHED",
+                "title": "Cerise Pro",
+                "typeId": 6
+              },
+              {
+                "averageRating": 0,
+                "description": "Outil de suivi et d'\u00e9valuation de comp\u00e9tences pour la formation professionnelle des STI                      CANOPE, bilan",
+                "favorite": false,
+                "fname": "CPRO-STI",
+                "id": 138,
+                "keywords": [],
+                "name": "Cerise Pro-STI",
+                "parameters": {
+                  "alternate": {
+                    "description": "",
+                    "name": "alternate",
+                    "value": "false"
+                  },
+                  "alternativeMaximizedLink": {
+                    "description": "",
+                    "name": "alternativeMaximizedLink",
+                    "value": "/portail/api/ExternalURLStats?fname=CPRO-STI&service=/esco-apps-redirector/index.php?appli=CERISEPROSTI"
+                  },
+                  "blockImpersonation": {
+                    "description": "",
+                    "name": "blockImpersonation",
+                    "value": "true"
+                  },
+                  "editable": {
+                    "description": "",
+                    "name": "editable",
+                    "value": "false"
+                  },
+                  "hasAbout": {
+                    "description": "",
+                    "name": "hasAbout",
+                    "value": "false"
+                  },
+                  "hasHelp": {
+                    "description": "",
+                    "name": "hasHelp",
+                    "value": "false"
+                  },
+                  "hideFromDesktop": {
+                    "description": "",
+                    "name": "hideFromDesktop",
+                    "value": "false"
+                  },
+                  "hideFromMobile": {
+                    "description": "",
+                    "name": "hideFromMobile",
+                    "value": "false"
+                  },
+                  "highlight": {
+                    "description": "",
+                    "name": "highlight",
+                    "value": "false"
+                  },
+                  "iconUrl": {
+                    "description": "",
+                    "name": "iconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/CPRO.svg"
+                  },
+                  "locale": {
+                    "description": "",
+                    "name": "locale",
+                    "value": "false"
+                  },
+                  "mobileIconUrl": {
+                    "description": "",
+                    "name": "mobileIconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/CPRO.svg"
+                  },
+                  "printable": {
+                    "description": "",
+                    "name": "printable",
+                    "value": "false"
+                  },
+                  "secure": {
+                    "description": "",
+                    "name": "secure",
+                    "value": "false"
+                  },
+                  "showChrome": {
+                    "description": "",
+                    "name": "showChrome",
+                    "value": "true"
+                  }
+                },
+                "ratingsCount": 0,
+                "state": "PUBLISHED",
+                "title": "Cerise Pro-STI",
+                "typeId": 6
+              },
+              {
+                "averageRating": 0,
+                "description": "Outils et ressources p\u00e9dagogiques, suivis de projets et actualit\u00e9s du CFA de la Ville de Tours               vie scolaire, apprentissage, p\u00e9dagogie",
+                "favorite": false,
+                "fname": "EchoSpheres",
+                "id": 59,
+                "keywords": [],
+                "name": "EchoSph\u00e8res",
+                "parameters": {
+                  "alternate": {
+                    "description": "",
+                    "name": "alternate",
+                    "value": "false"
+                  },
+                  "alternativeMaximizedLink": {
+                    "description": "",
+                    "name": "alternativeMaximizedLink",
+                    "value": "https://www.cfa-tours.fr/CAS/index.php"
+                  },
+                  "blockImpersonation": {
+                    "description": "",
+                    "name": "blockImpersonation",
+                    "value": "true"
+                  },
+                  "disableDynamicTitle": {
+                    "description": "",
+                    "name": "disableDynamicTitle",
+                    "value": "true"
+                  },
+                  "editable": {
+                    "description": "",
+                    "name": "editable",
+                    "value": "false"
+                  },
+                  "hasAbout": {
+                    "description": "",
+                    "name": "hasAbout",
+                    "value": "false"
+                  },
+                  "hasHelp": {
+                    "description": "",
+                    "name": "hasHelp",
+                    "value": "false"
+                  },
+                  "hideFromDesktop": {
+                    "description": "",
+                    "name": "hideFromDesktop",
+                    "value": "false"
+                  },
+                  "hideFromMobile": {
+                    "description": "",
+                    "name": "hideFromMobile",
+                    "value": "false"
+                  },
+                  "highlight": {
+                    "description": "",
+                    "name": "highlight",
+                    "value": "false"
+                  },
+                  "iconUrl": {
+                    "description": "",
+                    "name": "iconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/EchoSpheres.svg"
+                  },
+                  "locale": {
+                    "description": "",
+                    "name": "locale",
+                    "value": "false"
+                  },
+                  "mobileIconUrl": {
+                    "description": "",
+                    "name": "mobileIconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/EchoSpheres.svg"
+                  },
+                  "printable": {
+                    "description": "",
+                    "name": "printable",
+                    "value": "false"
+                  },
+                  "secure": {
+                    "description": "",
+                    "name": "secure",
+                    "value": "false"
+                  },
+                  "showChrome": {
+                    "description": "",
+                    "name": "showChrome",
+                    "value": "true"
+                  }
+                },
+                "ratingsCount": 0,
+                "state": "PUBLISHED",
+                "title": "EchoSph\u00e8res",
+                "typeId": 6
+              },
+              {
+                "averageRating": 0,
+                "description": "Acc\u00e8s \u00e0 l'espace Vie Scolaire de l'\u00e9tablissement                                                             Pronote, cahier de texte, emploi du temps, suivi, scolarit\u00e9, notes, absences, contr\u00f4les, saisies, consultation, bulletins, conseil de classe",
+                "favorite": false,
+                "fname": "VieScolaire",
+                "id": 107,
+                "keywords": [],
+                "name": "Espace Vie Scolaire",
+                "parameters": {
+                  "alternate": {
+                    "description": "",
+                    "name": "alternate",
+                    "value": "false"
+                  },
+                  "alternativeMaximizedLink": {
+                    "description": "",
+                    "name": "alternativeMaximizedLink",
+                    "value": "/portail/api/ExternalURLStats?fname=VieScolaire&service=/esco-apps-redirector/index.php?appli=VIESCOLAIRE"
+                  },
+                  "blockImpersonation": {
+                    "description": "",
+                    "name": "blockImpersonation",
+                    "value": "true"
+                  },
+                  "editable": {
+                    "description": "",
+                    "name": "editable",
+                    "value": "false"
+                  },
+                  "hasAbout": {
+                    "description": "",
+                    "name": "hasAbout",
+                    "value": "false"
+                  },
+                  "hasHelp": {
+                    "description": "",
+                    "name": "hasHelp",
+                    "value": "false"
+                  },
+                  "hideFromDesktop": {
+                    "description": "",
+                    "name": "hideFromDesktop",
+                    "value": "false"
+                  },
+                  "hideFromMobile": {
+                    "description": "",
+                    "name": "hideFromMobile",
+                    "value": "false"
+                  },
+                  "highlight": {
+                    "description": "",
+                    "name": "highlight",
+                    "value": "false"
+                  },
+                  "iconUrl": {
+                    "description": "",
+                    "name": "iconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/VieScolaire.svg"
+                  },
+                  "locale": {
+                    "description": "",
+                    "name": "locale",
+                    "value": "false"
+                  },
+                  "mobileIconUrl": {
+                    "description": "",
+                    "name": "mobileIconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/VieScolaire.svg"
+                  },
+                  "printable": {
+                    "description": "",
+                    "name": "printable",
+                    "value": "false"
+                  },
+                  "secure": {
+                    "description": "",
+                    "name": "secure",
+                    "value": "false"
+                  },
+                  "showChrome": {
+                    "description": "",
+                    "name": "showChrome",
+                    "value": "true"
+                  }
+                },
+                "ratingsCount": 0,
+                "state": "PUBLISHED",
+                "title": "Espace Vie Scolaire",
+                "typeId": 6
+              },
+              {
+                "averageRating": 0,
+                "description": "Plateforme p\u00e9dagogique Moodle (cours en ligne, ressources, exercices, entra\u00eenement, ...)                              tests, quizz, documentation, \u00e9valuation",
+                "favorite": false,
+                "fname": "MoodleMu",
+                "id": 84,
+                "keywords": [],
+                "name": "Espaces Moodle",
+                "parameters": {
+                  "alternate": {
+                    "description": "",
+                    "name": "alternate",
+                    "value": "false"
+                  },
+                  "alternativeMaximizedLink": {
+                    "description": "",
+                    "name": "alternativeMaximizedLink",
+                    "value": "/moodle/my"
+                  },
+                  "blockImpersonation": {
+                    "description": "",
+                    "name": "blockImpersonation",
+                    "value": "true"
+                  },
+                  "editable": {
+                    "description": "",
+                    "name": "editable",
+                    "value": "false"
+                  },
+                  "hasAbout": {
+                    "description": "",
+                    "name": "hasAbout",
+                    "value": "false"
+                  },
+                  "hasHelp": {
+                    "description": "",
+                    "name": "hasHelp",
+                    "value": "false"
+                  },
+                  "hideFromDesktop": {
+                    "description": "",
+                    "name": "hideFromDesktop",
+                    "value": "false"
+                  },
+                  "hideFromMobile": {
+                    "description": "",
+                    "name": "hideFromMobile",
+                    "value": "false"
+                  },
+                  "highlight": {
+                    "description": "",
+                    "name": "highlight",
+                    "value": "false"
+                  },
+                  "iconUrl": {
+                    "description": "",
+                    "name": "iconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/MoodleMu.svg"
+                  },
+                  "locale": {
+                    "description": "",
+                    "name": "locale",
+                    "value": "false"
+                  },
+                  "mobileIconUrl": {
+                    "description": "",
+                    "name": "mobileIconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/MoodleMu.svg"
+                  },
+                  "printable": {
+                    "description": "",
+                    "name": "printable",
+                    "value": "false"
+                  },
+                  "secure": {
+                    "description": "",
+                    "name": "secure",
+                    "value": "false"
+                  },
+                  "showChrome": {
+                    "description": "",
+                    "name": "showChrome",
+                    "value": "true"
+                  }
+                },
+                "ratingsCount": 0,
+                "state": "PUBLISHED",
+                "title": "Espaces Moodle",
+                "typeId": 6
+              },
+              {
+                "averageRating": 0,
+                "description": "Acc\u00e8s aux espaces de fichiers p\u00e9dagogiques de l'\u00e9tablissement                                                stocker, fichiers, r\u00e9pertoires, partage, partager, consultation, consulter",
+                "favorite": true,
+                "fname": "esup-filemanager",
+                "id": 116,
+                "keywords": [],
+                "name": "Espaces de stockage",
+                "parameters": {
+                  "alternate": {
+                    "description": "",
+                    "name": "alternate",
+                    "value": "false"
+                  },
+                  "blockImpersonation": {
+                    "description": "",
+                    "name": "blockImpersonation",
+                    "value": "false"
+                  },
+                  "disableDynamicTitle": {
+                    "description": "",
+                    "name": "disableDynamicTitle",
+                    "value": "true"
+                  },
+                  "editable": {
+                    "description": "",
+                    "name": "editable",
+                    "value": "false"
+                  },
+                  "hasAbout": {
+                    "description": "",
+                    "name": "hasAbout",
+                    "value": "false"
+                  },
+                  "hasHelp": {
+                    "description": "",
+                    "name": "hasHelp",
+                    "value": "false"
+                  },
+                  "hideFromDesktop": {
+                    "description": "",
+                    "name": "hideFromDesktop",
+                    "value": "false"
+                  },
+                  "hideFromMobile": {
+                    "description": "",
+                    "name": "hideFromMobile",
+                    "value": "false"
+                  },
+                  "highlight": {
+                    "description": "",
+                    "name": "highlight",
+                    "value": "false"
+                  },
+                  "iconUrl": {
+                    "description": "",
+                    "name": "iconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/esup-filemanager.svg"
+                  },
+                  "locale": {
+                    "description": "",
+                    "name": "locale",
+                    "value": "false"
+                  },
+                  "mobileIconUrl": {
+                    "description": "",
+                    "name": "mobileIconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/esup-filemanager.svg"
+                  },
+                  "printable": {
+                    "description": "",
+                    "name": "printable",
+                    "value": "false"
+                  },
+                  "secure": {
+                    "description": "",
+                    "name": "secure",
+                    "value": "false"
+                  },
+                  "showChrome": {
+                    "description": "",
+                    "name": "showChrome",
+                    "value": "true"
+                  }
+                },
+                "ratingsCount": 0,
+                "state": "PUBLISHED",
+                "title": "Espaces de stockage",
+                "typeId": 7
+              },
+              {
+                "averageRating": 0,
+                "description": "Ressources documentaires (PMB)                                                                               centre de documentation, information, biblioth\u00e8que, documentation, livres, scolaires, emprunt, emprunter, multi-m\u00e9dia, ressources, num\u00e9riques",
+                "favorite": false,
+                "fname": "PMB",
+                "id": 87,
+                "keywords": [],
+                "name": "Gestion documentaire",
+                "parameters": {
+                  "alternate": {
+                    "description": "",
+                    "name": "alternate",
+                    "value": "false"
+                  },
+                  "blockImpersonation": {
+                    "description": "",
+                    "name": "blockImpersonation",
+                    "value": "true"
+                  },
+                  "editable": {
+                    "description": "",
+                    "name": "editable",
+                    "value": "false"
+                  },
+                  "hasAbout": {
+                    "description": "",
+                    "name": "hasAbout",
+                    "value": "false"
+                  },
+                  "hasHelp": {
+                    "description": "",
+                    "name": "hasHelp",
+                    "value": "false"
+                  },
+                  "hideFromDesktop": {
+                    "description": "",
+                    "name": "hideFromDesktop",
+                    "value": "false"
+                  },
+                  "hideFromMobile": {
+                    "description": "",
+                    "name": "hideFromMobile",
+                    "value": "false"
+                  },
+                  "highlight": {
+                    "description": "",
+                    "name": "highlight",
+                    "value": "false"
+                  },
+                  "iconUrl": {
+                    "description": "",
+                    "name": "iconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/PMB.svg"
+                  },
+                  "locale": {
+                    "description": "",
+                    "name": "locale",
+                    "value": "false"
+                  },
+                  "mobileIconUrl": {
+                    "description": "",
+                    "name": "mobileIconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/PMB.svg"
+                  },
+                  "printable": {
+                    "description": "",
+                    "name": "printable",
+                    "value": "false"
+                  },
+                  "secure": {
+                    "description": "",
+                    "name": "secure",
+                    "value": "false"
+                  },
+                  "showChrome": {
+                    "description": "",
+                    "name": "showChrome",
+                    "value": "true"
+                  }
+                },
+                "ratingsCount": 0,
+                "state": "PUBLISHED",
+                "title": "Gestion documentaire",
+                "typeId": 6
+              },
+              {
+                "averageRating": 0,
+                "description": "Acc\u00e8s aux ressources des CDI du Lyc\u00e9e Th\u00e9r\u00e8se Planiol                                                        centre de documentation, information, biblioth\u00e8que, documentation, livres, scolaires, emprunter, multi-m\u00e9dia, ressources, num\u00e9riques, e-sidoc",
+                "favorite": false,
+                "fname": "CDITheresePlaniol",
+                "id": 48,
+                "keywords": [],
+                "name": "Les CDI Th\u00e9r\u00e8se Planiol",
+                "parameters": {
+                  "alternate": {
+                    "description": "",
+                    "name": "alternate",
+                    "value": "false"
+                  },
+                  "blockImpersonation": {
+                    "description": "",
+                    "name": "blockImpersonation",
+                    "value": "false"
+                  },
+                  "disableDynamicTitle": {
+                    "description": "",
+                    "name": "disableDynamicTitle",
+                    "value": "true"
+                  },
+                  "editable": {
+                    "description": "",
+                    "name": "editable",
+                    "value": "false"
+                  },
+                  "hasAbout": {
+                    "description": "",
+                    "name": "hasAbout",
+                    "value": "false"
+                  },
+                  "hasHelp": {
+                    "description": "",
+                    "name": "hasHelp",
+                    "value": "false"
+                  },
+                  "hideFromDesktop": {
+                    "description": "",
+                    "name": "hideFromDesktop",
+                    "value": "false"
+                  },
+                  "hideFromMobile": {
+                    "description": "",
+                    "name": "hideFromMobile",
+                    "value": "false"
+                  },
+                  "highlight": {
+                    "description": "",
+                    "name": "highlight",
+                    "value": "false"
+                  },
+                  "iconUrl": {
+                    "description": "",
+                    "name": "iconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/CDITheresePlaniol.svg"
+                  },
+                  "mobileIconUrl": {
+                    "description": "",
+                    "name": "mobileIconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/CDITheresePlaniol.svg"
+                  },
+                  "printable": {
+                    "description": "",
+                    "name": "printable",
+                    "value": "false"
+                  },
+                  "showChrome": {
+                    "description": "",
+                    "name": "showChrome",
+                    "value": "true"
+                  }
+                },
+                "ratingsCount": 0,
+                "state": "PUBLISHED",
+                "title": "Les CDI Th\u00e9r\u00e8se Planiol",
+                "typeId": 4
+              },
+              {
+                "averageRating": 0,
+                "description": "Livret Electronique d'Apprentissage                                                                          suivi, alternance, parcours, entreprises, ma\u00eetres de stage, ma\u00eetres d'apprentissage, comp\u00e9tences",
+                "favorite": false,
+                "fname": "LEA",
+                "id": 76,
+                "keywords": [],
+                "name": "Livret \u00c9lectronique d'Apprentissage",
+                "parameters": {
+                  "alternate": {
+                    "description": "",
+                    "name": "alternate",
+                    "value": "false"
+                  },
+                  "blockImpersonation": {
+                    "description": "",
+                    "name": "blockImpersonation",
+                    "value": "true"
+                  },
+                  "editable": {
+                    "description": "",
+                    "name": "editable",
+                    "value": "false"
+                  },
+                  "hasAbout": {
+                    "description": "",
+                    "name": "hasAbout",
+                    "value": "false"
+                  },
+                  "hasHelp": {
+                    "description": "",
+                    "name": "hasHelp",
+                    "value": "false"
+                  },
+                  "hideFromDesktop": {
+                    "description": "",
+                    "name": "hideFromDesktop",
+                    "value": "false"
+                  },
+                  "hideFromMobile": {
+                    "description": "",
+                    "name": "hideFromMobile",
+                    "value": "false"
+                  },
+                  "highlight": {
+                    "description": "",
+                    "name": "highlight",
+                    "value": "false"
+                  },
+                  "iconUrl": {
+                    "description": "",
+                    "name": "iconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/LEA.svg"
+                  },
+                  "locale": {
+                    "description": "",
+                    "name": "locale",
+                    "value": "false"
+                  },
+                  "mobileIconUrl": {
+                    "description": "",
+                    "name": "mobileIconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/LEA.svg"
+                  },
+                  "printable": {
+                    "description": "",
+                    "name": "printable",
+                    "value": "false"
+                  },
+                  "secure": {
+                    "description": "",
+                    "name": "secure",
+                    "value": "false"
+                  },
+                  "showChrome": {
+                    "description": "",
+                    "name": "showChrome",
+                    "value": "true"
+                  }
+                },
+                "ratingsCount": 0,
+                "state": "PUBLISHED",
+                "title": "Livret \u00c9lectronique d'Apprentissage",
+                "typeId": 6
+              },
+              {
+                "averageRating": 0,
+                "description": "Acc\u00e8s aux ressources num\u00e9riques mises \u00e0 ma disposition                                                   documents, \u00e9ducatives, scolaires, multim\u00e9dia, vid\u00e9os, manuels, abonnements",
+                "favorite": false,
+                "fname": "RessourcesNumeriques",
+                "id": 91,
+                "keywords": [],
+                "name": "Mes ressources num\u00e9riques",
+                "parameters": {
+                  "alternate": {
+                    "description": "",
+                    "name": "alternate",
+                    "value": "false"
+                  },
+                  "blockImpersonation": {
+                    "description": "",
+                    "name": "blockImpersonation",
+                    "value": "false"
+                  },
+                  "disableDynamicTitle": {
+                    "description": "",
+                    "name": "disableDynamicTitle",
+                    "value": "true"
+                  },
+                  "editable": {
+                    "description": "",
+                    "name": "editable",
+                    "value": "false"
+                  },
+                  "hasAbout": {
+                    "description": "",
+                    "name": "hasAbout",
+                    "value": "false"
+                  },
+                  "hasHelp": {
+                    "description": "",
+                    "name": "hasHelp",
+                    "value": "false"
+                  },
+                  "hideFromDesktop": {
+                    "description": "",
+                    "name": "hideFromDesktop",
+                    "value": "false"
+                  },
+                  "hideFromMobile": {
+                    "description": "",
+                    "name": "hideFromMobile",
+                    "value": "false"
+                  },
+                  "highlight": {
+                    "description": "",
+                    "name": "highlight",
+                    "value": "false"
+                  },
+                  "iconUrl": {
+                    "description": "",
+                    "name": "iconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/Mediacentre.svg"
+                  },
+                  "locale": {
+                    "description": "",
+                    "name": "locale",
+                    "value": "false"
+                  },
+                  "mobileIconUrl": {
+                    "description": "",
+                    "name": "mobileIconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/Mediacentre.svg"
+                  },
+                  "printable": {
+                    "description": "",
+                    "name": "printable",
+                    "value": "false"
+                  },
+                  "secure": {
+                    "description": "",
+                    "name": "secure",
+                    "value": "false"
+                  },
+                  "showChrome": {
+                    "description": "",
+                    "name": "showChrome",
+                    "value": "true"
+                  }
+                },
+                "ratingsCount": 0,
+                "state": "PUBLISHED",
+                "title": "Mes ressources num\u00e9riques",
+                "typeId": 7
+              },
+              {
+                "averageRating": 0,
+                "description": "Ensemble de ressources num\u00e9riques de diff\u00e9rents \u00e9diteurs, disponibles pour l'utilisateur                      documents, \u00e9ducatives, scolaires, multim\u00e9dia, vid\u00e9os, manuels, abonnements, GAR, gestionnaire acc\u00e8s aux ressources",
+                "favorite": false,
+                "fname": "Mediacentre",
+                "id": 81,
+                "keywords": [],
+                "name": "M\u00e9diacentre",
+                "parameters": {
+                  "alternate": {
+                    "description": "",
+                    "name": "alternate",
+                    "value": "false"
+                  },
+                  "blockImpersonation": {
+                    "description": "",
+                    "name": "blockImpersonation",
+                    "value": "false"
+                  },
+                  "disableDynamicTitle": {
+                    "description": "",
+                    "name": "disableDynamicTitle",
+                    "value": "true"
+                  },
+                  "editable": {
+                    "description": "",
+                    "name": "editable",
+                    "value": "false"
+                  },
+                  "hasAbout": {
+                    "description": "",
+                    "name": "hasAbout",
+                    "value": "false"
+                  },
+                  "hasHelp": {
+                    "description": "",
+                    "name": "hasHelp",
+                    "value": "false"
+                  },
+                  "hideFromDesktop": {
+                    "description": "",
+                    "name": "hideFromDesktop",
+                    "value": "false"
+                  },
+                  "hideFromMobile": {
+                    "description": "",
+                    "name": "hideFromMobile",
+                    "value": "false"
+                  },
+                  "highlight": {
+                    "description": "",
+                    "name": "highlight",
+                    "value": "false"
+                  },
+                  "iconUrl": {
+                    "description": "",
+                    "name": "iconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/Mediacentre.svg"
+                  },
+                  "locale": {
+                    "description": "",
+                    "name": "locale",
+                    "value": "false"
+                  },
+                  "mobileIconUrl": {
+                    "description": "",
+                    "name": "mobileIconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/Mediacentre.svg"
+                  },
+                  "printable": {
+                    "description": "",
+                    "name": "printable",
+                    "value": "false"
+                  },
+                  "secure": {
+                    "description": "",
+                    "name": "secure",
+                    "value": "false"
+                  },
+                  "showChrome": {
+                    "description": "",
+                    "name": "showChrome",
+                    "value": "true"
+                  }
+                },
+                "ratingsCount": 0,
+                "state": "PUBLISHED",
+                "title": "M\u00e9diacentre",
+                "typeId": 7
+              },
+              {
+                "averageRating": 0,
+                "description": "Plateforme de diffusion de vid\u00e9os",
+                "favorite": false,
+                "fname": "ESUPpodV2",
+                "id": 146,
+                "keywords": [],
+                "name": "Plateforme Vid\u00e9o",
+                "parameters": {
+                  "blockImpersonation": {
+                    "description": "",
+                    "name": "blockImpersonation",
+                    "value": "false"
+                  },
+                  "chromeStyle": {
+                    "description": "",
+                    "name": "chromeStyle",
+                    "value": "default"
+                  },
+                  "configurable": {
+                    "description": "",
+                    "name": "configurable",
+                    "value": "false"
+                  },
+                  "disableDynamicTitle": {
+                    "description": "",
+                    "name": "disableDynamicTitle",
+                    "value": "true"
+                  },
+                  "disablePortletEvents": {
+                    "description": "",
+                    "name": "disablePortletEvents",
+                    "value": "false"
+                  },
+                  "editable": {
+                    "description": "",
+                    "name": "editable",
+                    "value": "false"
+                  },
+                  "hasAbout": {
+                    "description": "",
+                    "name": "hasAbout",
+                    "value": "false"
+                  },
+                  "hasHelp": {
+                    "description": "",
+                    "name": "hasHelp",
+                    "value": "false"
+                  },
+                  "hideFromMobile": {
+                    "description": "",
+                    "name": "hideFromMobile",
+                    "value": "false"
+                  },
+                  "iconUrl": {
+                    "description": "",
+                    "name": "iconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/pod.png"
+                  },
+                  "mobileIconUrl": {
+                    "description": "",
+                    "name": "mobileIconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/pod.png"
+                  }
+                },
+                "ratingsCount": 0,
+                "state": "PUBLISHED",
+                "title": "Plateforme Vid\u00e9o",
+                "typeId": 6
+              },
+              {
+                "averageRating": 0,
+                "description": "Les ressources disponibles dans le CDI de l'\u00e9tablissement                                                    centre de documentation, information, biblioth\u00e8que, documentation, livres, scolaires, emprunt, emprunter, multi-m\u00e9dia, ressources, num\u00e9riques, PMB",
+                "favorite": false,
+                "fname": "PMB_LesCharmilles",
+                "id": 88,
+                "keywords": [],
+                "name": "Ressources du CDI",
+                "parameters": {
+                  "alternate": {
+                    "description": "",
+                    "name": "alternate",
+                    "value": "false"
+                  },
+                  "alternativeMaximizedLink": {
+                    "description": "",
+                    "name": "alternativeMaximizedLink",
+                    "value": "/portail/api/ExternalURLStats?fname=PMB&service=http://lp-charmilles-chateauroux.tice.ac-orleans-tours.fr/php5/pmb/opac_css/?database=DB_lp_charmilles_chateauroux_PHP5"
+                  },
+                  "blockImpersonation": {
+                    "description": "",
+                    "name": "blockImpersonation",
+                    "value": "true"
+                  },
+                  "disableDynamicTitle": {
+                    "description": "",
+                    "name": "disableDynamicTitle",
+                    "value": "true"
+                  },
+                  "editable": {
+                    "description": "",
+                    "name": "editable",
+                    "value": "false"
+                  },
+                  "hasAbout": {
+                    "description": "",
+                    "name": "hasAbout",
+                    "value": "false"
+                  },
+                  "hasHelp": {
+                    "description": "",
+                    "name": "hasHelp",
+                    "value": "false"
+                  },
+                  "hideFromDesktop": {
+                    "description": "",
+                    "name": "hideFromDesktop",
+                    "value": "false"
+                  },
+                  "hideFromMobile": {
+                    "description": "",
+                    "name": "hideFromMobile",
+                    "value": "false"
+                  },
+                  "highlight": {
+                    "description": "",
+                    "name": "highlight",
+                    "value": "false"
+                  },
+                  "iconUrl": {
+                    "description": "",
+                    "name": "iconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/PMB_LesCharmilles.svg"
+                  },
+                  "mobileIconUrl": {
+                    "description": "",
+                    "name": "mobileIconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/PMB_LesCharmilles.svg"
+                  },
+                  "printable": {
+                    "description": "",
+                    "name": "printable",
+                    "value": "false"
+                  },
+                  "showChrome": {
+                    "description": "",
+                    "name": "showChrome",
+                    "value": "true"
+                  }
+                },
+                "ratingsCount": 0,
+                "state": "PUBLISHED",
+                "title": "Ressources du CDI",
+                "typeId": 4
+              },
+              {
+                "averageRating": 0,
+                "description": "Vie scolaire (saisie des absences) de SIECLE pour les personnels de l'\u00c9ducation Nationale                      suivi, scolarit\u00e9, notes, contr\u00f4les, saisies, consultation, enseignant, bulletins de notes, acad\u00e9mie, acad\u00e9mique, Orl\u00e9ans, Tours, rectorat",
+                "favorite": false,
+                "fname": "SiecleVieScolaire",
+                "id": 102,
+                "keywords": [],
+                "name": "SIECLE Vie scolaire",
+                "parameters": {
+                  "alternate": {
+                    "description": "",
+                    "name": "alternate",
+                    "value": "false"
+                  },
+                  "alternativeMaximizedLink": {
+                    "description": "",
+                    "name": "alternativeMaximizedLink",
+                    "value": "/portail/api/ExternalURLStats?fname=SiecleVieScolaire&service=https://extraent.ac-orleans-tours.fr/viescolaire/"
+                  },
+                  "blockImpersonation": {
+                    "description": "",
+                    "name": "blockImpersonation",
+                    "value": "true"
+                  },
+                  "editable": {
+                    "description": "",
+                    "name": "editable",
+                    "value": "false"
+                  },
+                  "hasAbout": {
+                    "description": "",
+                    "name": "hasAbout",
+                    "value": "false"
+                  },
+                  "hasHelp": {
+                    "description": "",
+                    "name": "hasHelp",
+                    "value": "false"
+                  },
+                  "hideFromDesktop": {
+                    "description": "",
+                    "name": "hideFromDesktop",
+                    "value": "false"
+                  },
+                  "hideFromMobile": {
+                    "description": "",
+                    "name": "hideFromMobile",
+                    "value": "false"
+                  },
+                  "highlight": {
+                    "description": "",
+                    "name": "highlight",
+                    "value": "false"
+                  },
+                  "iconUrl": {
+                    "description": "",
+                    "name": "iconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/SiecleVieScolaire.svg"
+                  },
+                  "locale": {
+                    "description": "",
+                    "name": "locale",
+                    "value": "false"
+                  },
+                  "mobileIconUrl": {
+                    "description": "",
+                    "name": "mobileIconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/SiecleVieScolaire.svg"
+                  },
+                  "printable": {
+                    "description": "",
+                    "name": "printable",
+                    "value": "false"
+                  },
+                  "secure": {
+                    "description": "",
+                    "name": "secure",
+                    "value": "false"
+                  },
+                  "showChrome": {
+                    "description": "",
+                    "name": "showChrome",
+                    "value": "true"
+                  }
+                },
+                "ratingsCount": 0,
+                "state": "PUBLISHED",
+                "title": "SIECLE Vie scolaire",
+                "typeId": 6
+              },
+              {
+                "averageRating": 0,
+                "description": "Sconet Notes pour les responsables d'\u00e9tablissement de l'\u00c9ducation Nationale                                    suivi, scolarit\u00e9, notes, contr\u00f4les, saisies, consultation, enseignant, bulletins de notes, acad\u00e9mie, acad\u00e9mique, Orl\u00e9ans, Tours, rectorat",
+                "favorite": false,
+                "fname": "SconetNotes_chefetab",
+                "id": 99,
+                "keywords": [],
+                "name": "Sconet notes : Chef d'\u00e9tablissement",
+                "parameters": {
+                  "alternate": {
+                    "description": "",
+                    "name": "alternate",
+                    "value": "false"
+                  },
+                  "alternativeMaximizedLink": {
+                    "description": "",
+                    "name": "alternativeMaximizedLink",
+                    "value": "/portail/api/ExternalURLStats?fname=SconetNotes_chefetab&service=https://extraent.ac-orleans-tours.fr/sconetnotes/index.jsp"
+                  },
+                  "blockImpersonation": {
+                    "description": "",
+                    "name": "blockImpersonation",
+                    "value": "true"
+                  },
+                  "editable": {
+                    "description": "",
+                    "name": "editable",
+                    "value": "false"
+                  },
+                  "hasAbout": {
+                    "description": "",
+                    "name": "hasAbout",
+                    "value": "false"
+                  },
+                  "hasHelp": {
+                    "description": "",
+                    "name": "hasHelp",
+                    "value": "false"
+                  },
+                  "hideFromDesktop": {
+                    "description": "",
+                    "name": "hideFromDesktop",
+                    "value": "false"
+                  },
+                  "hideFromMobile": {
+                    "description": "",
+                    "name": "hideFromMobile",
+                    "value": "false"
+                  },
+                  "highlight": {
+                    "description": "",
+                    "name": "highlight",
+                    "value": "false"
+                  },
+                  "iconUrl": {
+                    "description": "",
+                    "name": "iconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/SconetNotes_chefetab.svg"
+                  },
+                  "locale": {
+                    "description": "",
+                    "name": "locale",
+                    "value": "false"
+                  },
+                  "mobileIconUrl": {
+                    "description": "",
+                    "name": "mobileIconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/SconetNotes_chefetab.svg"
+                  },
+                  "printable": {
+                    "description": "",
+                    "name": "printable",
+                    "value": "false"
+                  },
+                  "secure": {
+                    "description": "",
+                    "name": "secure",
+                    "value": "false"
+                  },
+                  "showChrome": {
+                    "description": "",
+                    "name": "showChrome",
+                    "value": "true"
+                  }
+                },
+                "ratingsCount": 0,
+                "state": "PUBLISHED",
+                "title": "Notes : Chef d'\u00e9tablissement",
+                "typeId": 6
+              },
+              {
+                "averageRating": 0,
+                "description": "Fiches p\u00e9dagogiques de Sconet pour les personnels de l'\u00c9ducation Nationale                                     suivi, scolarit\u00e9, notes, contr\u00f4les, saisies, consultation, enseignant, bulletins de notes, acad\u00e9mie, acad\u00e9mique, Orl\u00e9ans, Tours, rectorat",
+                "favorite": false,
+                "fname": "SconetNotes_peda",
+                "id": 100,
+                "keywords": [],
+                "name": "Sconet notes : fiche p\u00e9dagogique",
+                "parameters": {
+                  "alternate": {
+                    "description": "",
+                    "name": "alternate",
+                    "value": "false"
+                  },
+                  "alternativeMaximizedLink": {
+                    "description": "",
+                    "name": "alternativeMaximizedLink",
+                    "value": "/portail/api/ExternalURLStats?fname=SconetNotes_peda&service=https://extraent.ac-orleans-tours.fr/sconetnotesped/index.jsp"
+                  },
+                  "blockImpersonation": {
+                    "description": "",
+                    "name": "blockImpersonation",
+                    "value": "true"
+                  },
+                  "editable": {
+                    "description": "",
+                    "name": "editable",
+                    "value": "false"
+                  },
+                  "hasAbout": {
+                    "description": "",
+                    "name": "hasAbout",
+                    "value": "false"
+                  },
+                  "hasHelp": {
+                    "description": "",
+                    "name": "hasHelp",
+                    "value": "false"
+                  },
+                  "hideFromDesktop": {
+                    "description": "",
+                    "name": "hideFromDesktop",
+                    "value": "false"
+                  },
+                  "hideFromMobile": {
+                    "description": "",
+                    "name": "hideFromMobile",
+                    "value": "false"
+                  },
+                  "highlight": {
+                    "description": "",
+                    "name": "highlight",
+                    "value": "false"
+                  },
+                  "iconUrl": {
+                    "description": "",
+                    "name": "iconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/SconetNotes_peda.svg"
+                  },
+                  "locale": {
+                    "description": "",
+                    "name": "locale",
+                    "value": "false"
+                  },
+                  "mobileIconUrl": {
+                    "description": "",
+                    "name": "mobileIconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/SconetNotes_peda.svg"
+                  },
+                  "printable": {
+                    "description": "",
+                    "name": "printable",
+                    "value": "false"
+                  },
+                  "secure": {
+                    "description": "",
+                    "name": "secure",
+                    "value": "false"
+                  },
+                  "showChrome": {
+                    "description": "",
+                    "name": "showChrome",
+                    "value": "true"
+                  }
+                },
+                "ratingsCount": 0,
+                "state": "PUBLISHED",
+                "title": "Notes : fiche p\u00e9dagogique",
+                "typeId": 6
+              },
+              {
+                "averageRating": 0,
+                "description": "Sconet Notes pour les enseignants de l'\u00c9ducation Nationale                                                     suivi, scolarit\u00e9, notes, contr\u00f4les, saisies, consultation, enseignant, bulletins de notes, acad\u00e9mie, acad\u00e9mique, Orl\u00e9ans, Tours, rectorat",
+                "favorite": false,
+                "fname": "SconetNotes",
+                "id": 98,
+                "keywords": [],
+                "name": "Sconet notes : saisie des notes enseignant",
+                "parameters": {
+                  "alternate": {
+                    "description": "",
+                    "name": "alternate",
+                    "value": "false"
+                  },
+                  "alternativeMaximizedLink": {
+                    "description": "",
+                    "name": "alternativeMaximizedLink",
+                    "value": "/portail/api/ExternalURLStats?fname=SconetNotes&service=https://extraent.ac-orleans-tours.fr/sconetnotesens/index.jsp"
+                  },
+                  "blockImpersonation": {
+                    "description": "",
+                    "name": "blockImpersonation",
+                    "value": "true"
+                  },
+                  "editable": {
+                    "description": "",
+                    "name": "editable",
+                    "value": "false"
+                  },
+                  "hasAbout": {
+                    "description": "",
+                    "name": "hasAbout",
+                    "value": "false"
+                  },
+                  "hasHelp": {
+                    "description": "",
+                    "name": "hasHelp",
+                    "value": "false"
+                  },
+                  "hideFromDesktop": {
+                    "description": "",
+                    "name": "hideFromDesktop",
+                    "value": "false"
+                  },
+                  "hideFromMobile": {
+                    "description": "",
+                    "name": "hideFromMobile",
+                    "value": "false"
+                  },
+                  "highlight": {
+                    "description": "",
+                    "name": "highlight",
+                    "value": "false"
+                  },
+                  "iconUrl": {
+                    "description": "",
+                    "name": "iconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/SconetNotes.svg"
+                  },
+                  "locale": {
+                    "description": "",
+                    "name": "locale",
+                    "value": "false"
+                  },
+                  "mobileIconUrl": {
+                    "description": "",
+                    "name": "mobileIconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/SconetNotes.svg"
+                  },
+                  "printable": {
+                    "description": "",
+                    "name": "printable",
+                    "value": "false"
+                  },
+                  "secure": {
+                    "description": "",
+                    "name": "secure",
+                    "value": "false"
+                  },
+                  "showChrome": {
+                    "description": "",
+                    "name": "showChrome",
+                    "value": "true"
+                  }
+                },
+                "ratingsCount": 0,
+                "state": "PUBLISHED",
+                "title": "Saisie des notes",
+                "typeId": 6
+              },
+              {
+                "averageRating": 0,
+                "description": "Sconet Notes - vie scolaire pour les personnels de l'\u00c9ducation Nationale                                     suivi, scolarit\u00e9, notes, contr\u00f4les, saisies, consultation, enseignant, bulletins de notes, acad\u00e9mie, acad\u00e9mique, Orl\u00e9ans, Tours, rectorat",
+                "favorite": false,
+                "fname": "SconetNotes_viesco",
+                "id": 101,
+                "keywords": [],
+                "name": "Sconet notes : vie scolaire",
+                "parameters": {
+                  "alternate": {
+                    "description": "",
+                    "name": "alternate",
+                    "value": "false"
+                  },
+                  "alternativeMaximizedLink": {
+                    "description": "",
+                    "name": "alternativeMaximizedLink",
+                    "value": "/portail/api/ExternalURLStats?fname=SconetNotes_viesco&service=https://extraent.ac-orleans-tours.fr/sconetnotesvisco/index.jsp"
+                  },
+                  "blockImpersonation": {
+                    "description": "",
+                    "name": "blockImpersonation",
+                    "value": "true"
+                  },
+                  "editable": {
+                    "description": "",
+                    "name": "editable",
+                    "value": "false"
+                  },
+                  "hasAbout": {
+                    "description": "",
+                    "name": "hasAbout",
+                    "value": "false"
+                  },
+                  "hasHelp": {
+                    "description": "",
+                    "name": "hasHelp",
+                    "value": "false"
+                  },
+                  "hideFromDesktop": {
+                    "description": "",
+                    "name": "hideFromDesktop",
+                    "value": "false"
+                  },
+                  "hideFromMobile": {
+                    "description": "",
+                    "name": "hideFromMobile",
+                    "value": "false"
+                  },
+                  "highlight": {
+                    "description": "",
+                    "name": "highlight",
+                    "value": "false"
+                  },
+                  "iconUrl": {
+                    "description": "",
+                    "name": "iconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/SconetNotes_viesco.svg"
+                  },
+                  "locale": {
+                    "description": "",
+                    "name": "locale",
+                    "value": "false"
+                  },
+                  "mobileIconUrl": {
+                    "description": "",
+                    "name": "mobileIconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/SconetNotes_viesco.svg"
+                  },
+                  "printable": {
+                    "description": "",
+                    "name": "printable",
+                    "value": "false"
+                  },
+                  "secure": {
+                    "description": "",
+                    "name": "secure",
+                    "value": "false"
+                  },
+                  "showChrome": {
+                    "description": "",
+                    "name": "showChrome",
+                    "value": "true"
+                  }
+                },
+                "ratingsCount": 0,
+                "state": "PUBLISHED",
+                "title": "Notes : vie scolaire",
+                "typeId": 6
+              },
+              {
+                "averageRating": 0,
+                "description": "T\u00e9l\u00e9services de l'acad\u00e9mie d'Orl\u00e9ans-Tours                                                                   si\u00e8cle, sconet, cahier de texte, emploi du temps, suivi, scolarit\u00e9, notes, absences, contr\u00f4les, consultation, conseil de classe, acad\u00e9mique",
+                "favorite": false,
+                "fname": "Teleservices",
+                "id": 105,
+                "keywords": [],
+                "name": "T\u00e9l\u00e9services",
+                "parameters": {
+                  "alternate": {
+                    "description": "",
+                    "name": "alternate",
+                    "value": "false"
+                  },
+                  "alternativeMaximizedLink": {
+                    "description": "",
+                    "name": "alternativeMaximizedLink",
+                    "value": "/portail/api/ExternalURLStats?fname=Teleservices&service=https://portail-famille.ac-orleans-tours.fr"
+                  },
+                  "blockImpersonation": {
+                    "description": "",
+                    "name": "blockImpersonation",
+                    "value": "true"
+                  },
+                  "disableDynamicTitle": {
+                    "description": "",
+                    "name": "disableDynamicTitle",
+                    "value": "true"
+                  },
+                  "editable": {
+                    "description": "",
+                    "name": "editable",
+                    "value": "false"
+                  },
+                  "hasAbout": {
+                    "description": "",
+                    "name": "hasAbout",
+                    "value": "false"
+                  },
+                  "hasHelp": {
+                    "description": "",
+                    "name": "hasHelp",
+                    "value": "false"
+                  },
+                  "hideFromDesktop": {
+                    "description": "",
+                    "name": "hideFromDesktop",
+                    "value": "false"
+                  },
+                  "hideFromMobile": {
+                    "description": "",
+                    "name": "hideFromMobile",
+                    "value": "false"
+                  },
+                  "highlight": {
+                    "description": "",
+                    "name": "highlight",
+                    "value": "false"
+                  },
+                  "iconUrl": {
+                    "description": "",
+                    "name": "iconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/Teleservices.svg"
+                  },
+                  "locale": {
+                    "description": "",
+                    "name": "locale",
+                    "value": "false"
+                  },
+                  "mobileIconUrl": {
+                    "description": "",
+                    "name": "mobileIconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/Teleservices.svg"
+                  },
+                  "printable": {
+                    "description": "",
+                    "name": "printable",
+                    "value": "false"
+                  },
+                  "secure": {
+                    "description": "",
+                    "name": "secure",
+                    "value": "false"
+                  },
+                  "showChrome": {
+                    "description": "",
+                    "name": "showChrome",
+                    "value": "true"
+                  }
+                },
+                "ratingsCount": 0,
+                "state": "PUBLISHED",
+                "title": "T\u00e9l\u00e9services",
+                "typeId": 6
+              },
+              {
+                "averageRating": 0,
+                "description": "Informations sur la vie \u00e9tudiante \u00e0 l'ITS de Tours                                                           \u00e9tudiants, apprenti, social, informations, formations, h\u00e9bergement, bourses, aides, assistance",
+                "favorite": false,
+                "fname": "ITS-Tours_VieEtudiante",
+                "id": 134,
+                "keywords": [],
+                "name": "Vie \u00e9tudiante \u00e0 l'ITS",
+                "parameters": {
+                  "alternate": {
+                    "description": "",
+                    "name": "alternate",
+                    "value": "false"
+                  },
+                  "blockImpersonation": {
+                    "description": "",
+                    "name": "blockImpersonation",
+                    "value": "false"
+                  },
+                  "chromeStyle": {
+                    "description": "",
+                    "name": "chromeStyle",
+                    "value": "default"
+                  },
+                  "configurable": {
+                    "description": "",
+                    "name": "configurable",
+                    "value": "false"
+                  },
+                  "disableDynamicTitle": {
+                    "description": "",
+                    "name": "disableDynamicTitle",
+                    "value": "true"
+                  },
+                  "disablePortletEvents": {
+                    "description": "",
+                    "name": "disablePortletEvents",
+                    "value": "false"
+                  },
+                  "editable": {
+                    "description": "",
+                    "name": "editable",
+                    "value": "false"
+                  },
+                  "hasAbout": {
+                    "description": "",
+                    "name": "hasAbout",
+                    "value": "false"
+                  },
+                  "hasHelp": {
+                    "description": "",
+                    "name": "hasHelp",
+                    "value": "false"
+                  },
+                  "hideFromDesktop": {
+                    "description": "",
+                    "name": "hideFromDesktop",
+                    "value": "false"
+                  },
+                  "hideFromMobile": {
+                    "description": "",
+                    "name": "hideFromMobile",
+                    "value": "false"
+                  },
+                  "highlight": {
+                    "description": "",
+                    "name": "highlight",
+                    "value": "false"
+                  },
+                  "iconUrl": {
+                    "description": "",
+                    "name": "iconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/ItsTours_VieEtudiante.svg"
+                  },
+                  "mobileIconUrl": {
+                    "description": "",
+                    "name": "mobileIconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/ItsTours_VieEtudiante.svg"
+                  },
+                  "printable": {
+                    "description": "",
+                    "name": "printable",
+                    "value": "false"
+                  },
+                  "showChrome": {
+                    "description": "",
+                    "name": "showChrome",
+                    "value": "true"
+                  }
+                },
+                "ratingsCount": 0,
+                "state": "PUBLISHED",
+                "title": "Vie \u00e9tudiante \u00e0 l'ITS",
+                "typeId": 4
+              },
+              {
+                "averageRating": 0,
+                "description": "Acc\u00e8s au portail web Ypar\u00e9o                                                                                  Ymag, suivi, alternance, emploi du temps, scolarit\u00e9, notes, absences, contr\u00f4les, saisies, calendrier, consultation, bulletins, conseil de classe",
+                "favorite": false,
+                "fname": "Ypareo",
+                "id": 111,
+                "keywords": [],
+                "name": "Ypar\u00e9o",
+                "parameters": {
+                  "alternate": {
+                    "description": "",
+                    "name": "alternate",
+                    "value": "false"
+                  },
+                  "alternativeMaximizedLink": {
+                    "description": "",
+                    "name": "alternativeMaximizedLink",
+                    "value": "/portail/api/ExternalURLStats?fname=Ypareo&service=/esco-apps-redirector/index.php?appli=YPAREO"
+                  },
+                  "blockImpersonation": {
+                    "description": "",
+                    "name": "blockImpersonation",
+                    "value": "true"
+                  },
+                  "editable": {
+                    "description": "",
+                    "name": "editable",
+                    "value": "false"
+                  },
+                  "hasAbout": {
+                    "description": "",
+                    "name": "hasAbout",
+                    "value": "false"
+                  },
+                  "hasHelp": {
+                    "description": "",
+                    "name": "hasHelp",
+                    "value": "false"
+                  },
+                  "hideFromDesktop": {
+                    "description": "",
+                    "name": "hideFromDesktop",
+                    "value": "false"
+                  },
+                  "hideFromMobile": {
+                    "description": "",
+                    "name": "hideFromMobile",
+                    "value": "false"
+                  },
+                  "highlight": {
+                    "description": "",
+                    "name": "highlight",
+                    "value": "false"
+                  },
+                  "iconUrl": {
+                    "description": "",
+                    "name": "iconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/Ypareo.svg"
+                  },
+                  "locale": {
+                    "description": "",
+                    "name": "locale",
+                    "value": "false"
+                  },
+                  "mobileIconUrl": {
+                    "description": "",
+                    "name": "mobileIconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/Ypareo.svg"
+                  },
+                  "printable": {
+                    "description": "",
+                    "name": "printable",
+                    "value": "false"
+                  },
+                  "secure": {
+                    "description": "",
+                    "name": "secure",
+                    "value": "false"
+                  }
+                },
+                "ratingsCount": 0,
+                "state": "PUBLISHED",
+                "title": "Suivi administratif",
+                "typeId": 6
+              }
+            ],
+            "subcategories": []
+          },
+          {
+            "description": "Services li\u00e9s aux ressources multim\u00e9dia",
+            "id": "local.36",
+            "name": "Ressources multim\u00e9dia - documentations",
+            "portlets": [
+              {
+                "averageRating": 0,
+                "description": "Acc\u00e8s aux ressources du CDI                                                                                  centre de documentation, information, biblioth\u00e8que, documentation, livres, scolaires, emprunter, multi-m\u00e9dia, ressources, num\u00e9riques, e-sidoc",
+                "favorite": false,
+                "fname": "MonCDIPLCourier",
+                "id": 83,
+                "keywords": [],
+                "name": "CDI du coll\u00e8ge",
+                "parameters": {
+                  "alternate": {
+                    "description": "",
+                    "name": "alternate",
+                    "value": "false"
+                  },
+                  "alternativeMaximizedLink": {
+                    "description": "",
+                    "name": "alternativeMaximizedLink",
+                    "value": "/portail/api/ExternalURLStats?fname=ESIDOC&service=https://0379998s.esidoc.fr/home/"
+                  },
+                  "blockImpersonation": {
+                    "description": "",
+                    "name": "blockImpersonation",
+                    "value": "false"
+                  },
+                  "disableDynamicTitle": {
+                    "description": "",
+                    "name": "disableDynamicTitle",
+                    "value": "true"
+                  },
+                  "editable": {
+                    "description": "",
+                    "name": "editable",
+                    "value": "false"
+                  },
+                  "hasAbout": {
+                    "description": "",
+                    "name": "hasAbout",
+                    "value": "false"
+                  },
+                  "hasHelp": {
+                    "description": "",
+                    "name": "hasHelp",
+                    "value": "false"
+                  },
+                  "hideFromDesktop": {
+                    "description": "",
+                    "name": "hideFromDesktop",
+                    "value": "false"
+                  },
+                  "hideFromMobile": {
+                    "description": "",
+                    "name": "hideFromMobile",
+                    "value": "false"
+                  },
+                  "highlight": {
+                    "description": "",
+                    "name": "highlight",
+                    "value": "false"
+                  },
+                  "iconUrl": {
+                    "description": "",
+                    "name": "iconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/MonCDIPLCourier.svg"
+                  },
+                  "mobileIconUrl": {
+                    "description": "",
+                    "name": "mobileIconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/MonCDIPLCourier.svg"
+                  },
+                  "printable": {
+                    "description": "",
+                    "name": "printable",
+                    "value": "false"
+                  },
+                  "showChrome": {
+                    "description": "",
+                    "name": "showChrome",
+                    "value": "true"
+                  }
+                },
+                "ratingsCount": 0,
+                "state": "PUBLISHED",
+                "title": "CDI du coll\u00e8ge",
+                "typeId": 4
+              },
+              {
+                "averageRating": 0,
+                "description": "Les documents mis \u00e0 disposition par l'\u00e9tablissement                                                            lyc\u00e9e, coll\u00e8ge, CFA, ITS, formulaires, notes, compte-rendus, notices, r\u00e9glements",
+                "favorite": false,
+                "fname": "DocumentsEtab",
+                "id": 55,
+                "keywords": [],
+                "name": "Documents de l'\u00e9tablissement",
+                "parameters": {
+                  "alternate": {
+                    "description": "",
+                    "name": "alternate",
+                    "value": "false"
+                  },
+                  "blockImpersonation": {
+                    "description": "",
+                    "name": "blockImpersonation",
+                    "value": "false"
+                  },
+                  "disableDynamicTitle": {
+                    "description": "",
+                    "name": "disableDynamicTitle",
+                    "value": "true"
+                  },
+                  "editable": {
+                    "description": "",
+                    "name": "editable",
+                    "value": "false"
+                  },
+                  "hasAbout": {
+                    "description": "",
+                    "name": "hasAbout",
+                    "value": "false"
+                  },
+                  "hasHelp": {
+                    "description": "",
+                    "name": "hasHelp",
+                    "value": "false"
+                  },
+                  "hideFromDesktop": {
+                    "description": "",
+                    "name": "hideFromDesktop",
+                    "value": "false"
+                  },
+                  "hideFromMobile": {
+                    "description": "",
+                    "name": "hideFromMobile",
+                    "value": "false"
+                  },
+                  "highlight": {
+                    "description": "",
+                    "name": "highlight",
+                    "value": "false"
+                  },
+                  "iconUrl": {
+                    "description": "",
+                    "name": "iconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/DocumentsEtab.svg"
+                  },
+                  "locale": {
+                    "description": "",
+                    "name": "locale",
+                    "value": "false"
+                  },
+                  "mobileIconUrl": {
+                    "description": "",
+                    "name": "mobileIconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/DocumentsEtab.svg"
+                  },
+                  "printable": {
+                    "description": "",
+                    "name": "printable",
+                    "value": "false"
+                  },
+                  "secure": {
+                    "description": "",
+                    "name": "secure",
+                    "value": "false"
+                  },
+                  "showChrome": {
+                    "description": "",
+                    "name": "showChrome",
+                    "value": "true"
+                  }
+                },
+                "ratingsCount": 0,
+                "state": "PUBLISHED",
+                "title": "Documents de l'\u00e9tablissement",
+                "typeId": 7
+              },
+              {
+                "averageRating": 0,
+                "description": "Plateforme p\u00e9dagogique Moodle (cours en ligne, ressources, exercices, entra\u00eenement, ...)                              tests, quizz, documentation, \u00e9valuation",
+                "favorite": false,
+                "fname": "MoodleMu",
+                "id": 84,
+                "keywords": [],
+                "name": "Espaces Moodle",
+                "parameters": {
+                  "alternate": {
+                    "description": "",
+                    "name": "alternate",
+                    "value": "false"
+                  },
+                  "alternativeMaximizedLink": {
+                    "description": "",
+                    "name": "alternativeMaximizedLink",
+                    "value": "/moodle/my"
+                  },
+                  "blockImpersonation": {
+                    "description": "",
+                    "name": "blockImpersonation",
+                    "value": "true"
+                  },
+                  "editable": {
+                    "description": "",
+                    "name": "editable",
+                    "value": "false"
+                  },
+                  "hasAbout": {
+                    "description": "",
+                    "name": "hasAbout",
+                    "value": "false"
+                  },
+                  "hasHelp": {
+                    "description": "",
+                    "name": "hasHelp",
+                    "value": "false"
+                  },
+                  "hideFromDesktop": {
+                    "description": "",
+                    "name": "hideFromDesktop",
+                    "value": "false"
+                  },
+                  "hideFromMobile": {
+                    "description": "",
+                    "name": "hideFromMobile",
+                    "value": "false"
+                  },
+                  "highlight": {
+                    "description": "",
+                    "name": "highlight",
+                    "value": "false"
+                  },
+                  "iconUrl": {
+                    "description": "",
+                    "name": "iconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/MoodleMu.svg"
+                  },
+                  "locale": {
+                    "description": "",
+                    "name": "locale",
+                    "value": "false"
+                  },
+                  "mobileIconUrl": {
+                    "description": "",
+                    "name": "mobileIconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/MoodleMu.svg"
+                  },
+                  "printable": {
+                    "description": "",
+                    "name": "printable",
+                    "value": "false"
+                  },
+                  "secure": {
+                    "description": "",
+                    "name": "secure",
+                    "value": "false"
+                  },
+                  "showChrome": {
+                    "description": "",
+                    "name": "showChrome",
+                    "value": "true"
+                  }
+                },
+                "ratingsCount": 0,
+                "state": "PUBLISHED",
+                "title": "Espaces Moodle",
+                "typeId": 6
+              },
+              {
+                "averageRating": 0,
+                "description": "Acc\u00e8s aux espaces de fichiers p\u00e9dagogiques de l'\u00e9tablissement                                                stocker, fichiers, r\u00e9pertoires, partage, partager, consultation, consulter",
+                "favorite": true,
+                "fname": "esup-filemanager",
+                "id": 116,
+                "keywords": [],
+                "name": "Espaces de stockage",
+                "parameters": {
+                  "alternate": {
+                    "description": "",
+                    "name": "alternate",
+                    "value": "false"
+                  },
+                  "blockImpersonation": {
+                    "description": "",
+                    "name": "blockImpersonation",
+                    "value": "false"
+                  },
+                  "disableDynamicTitle": {
+                    "description": "",
+                    "name": "disableDynamicTitle",
+                    "value": "true"
+                  },
+                  "editable": {
+                    "description": "",
+                    "name": "editable",
+                    "value": "false"
+                  },
+                  "hasAbout": {
+                    "description": "",
+                    "name": "hasAbout",
+                    "value": "false"
+                  },
+                  "hasHelp": {
+                    "description": "",
+                    "name": "hasHelp",
+                    "value": "false"
+                  },
+                  "hideFromDesktop": {
+                    "description": "",
+                    "name": "hideFromDesktop",
+                    "value": "false"
+                  },
+                  "hideFromMobile": {
+                    "description": "",
+                    "name": "hideFromMobile",
+                    "value": "false"
+                  },
+                  "highlight": {
+                    "description": "",
+                    "name": "highlight",
+                    "value": "false"
+                  },
+                  "iconUrl": {
+                    "description": "",
+                    "name": "iconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/esup-filemanager.svg"
+                  },
+                  "locale": {
+                    "description": "",
+                    "name": "locale",
+                    "value": "false"
+                  },
+                  "mobileIconUrl": {
+                    "description": "",
+                    "name": "mobileIconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/esup-filemanager.svg"
+                  },
+                  "printable": {
+                    "description": "",
+                    "name": "printable",
+                    "value": "false"
+                  },
+                  "secure": {
+                    "description": "",
+                    "name": "secure",
+                    "value": "false"
+                  },
+                  "showChrome": {
+                    "description": "",
+                    "name": "showChrome",
+                    "value": "true"
+                  }
+                },
+                "ratingsCount": 0,
+                "state": "PUBLISHED",
+                "title": "Espaces de stockage",
+                "typeId": 7
+              },
+              {
+                "averageRating": 0,
+                "description": "Ressources documentaires (PMB)                                                                               centre de documentation, information, biblioth\u00e8que, documentation, livres, scolaires, emprunt, emprunter, multi-m\u00e9dia, ressources, num\u00e9riques",
+                "favorite": false,
+                "fname": "PMB",
+                "id": 87,
+                "keywords": [],
+                "name": "Gestion documentaire",
+                "parameters": {
+                  "alternate": {
+                    "description": "",
+                    "name": "alternate",
+                    "value": "false"
+                  },
+                  "blockImpersonation": {
+                    "description": "",
+                    "name": "blockImpersonation",
+                    "value": "true"
+                  },
+                  "editable": {
+                    "description": "",
+                    "name": "editable",
+                    "value": "false"
+                  },
+                  "hasAbout": {
+                    "description": "",
+                    "name": "hasAbout",
+                    "value": "false"
+                  },
+                  "hasHelp": {
+                    "description": "",
+                    "name": "hasHelp",
+                    "value": "false"
+                  },
+                  "hideFromDesktop": {
+                    "description": "",
+                    "name": "hideFromDesktop",
+                    "value": "false"
+                  },
+                  "hideFromMobile": {
+                    "description": "",
+                    "name": "hideFromMobile",
+                    "value": "false"
+                  },
+                  "highlight": {
+                    "description": "",
+                    "name": "highlight",
+                    "value": "false"
+                  },
+                  "iconUrl": {
+                    "description": "",
+                    "name": "iconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/PMB.svg"
+                  },
+                  "locale": {
+                    "description": "",
+                    "name": "locale",
+                    "value": "false"
+                  },
+                  "mobileIconUrl": {
+                    "description": "",
+                    "name": "mobileIconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/PMB.svg"
+                  },
+                  "printable": {
+                    "description": "",
+                    "name": "printable",
+                    "value": "false"
+                  },
+                  "secure": {
+                    "description": "",
+                    "name": "secure",
+                    "value": "false"
+                  },
+                  "showChrome": {
+                    "description": "",
+                    "name": "showChrome",
+                    "value": "true"
+                  }
+                },
+                "ratingsCount": 0,
+                "state": "PUBLISHED",
+                "title": "Gestion documentaire",
+                "typeId": 6
+              },
+              {
+                "averageRating": 0,
+                "description": "Acc\u00e8s aux ressources des CDI du Lyc\u00e9e Th\u00e9r\u00e8se Planiol                                                        centre de documentation, information, biblioth\u00e8que, documentation, livres, scolaires, emprunter, multi-m\u00e9dia, ressources, num\u00e9riques, e-sidoc",
+                "favorite": false,
+                "fname": "CDITheresePlaniol",
+                "id": 48,
+                "keywords": [],
+                "name": "Les CDI Th\u00e9r\u00e8se Planiol",
+                "parameters": {
+                  "alternate": {
+                    "description": "",
+                    "name": "alternate",
+                    "value": "false"
+                  },
+                  "blockImpersonation": {
+                    "description": "",
+                    "name": "blockImpersonation",
+                    "value": "false"
+                  },
+                  "disableDynamicTitle": {
+                    "description": "",
+                    "name": "disableDynamicTitle",
+                    "value": "true"
+                  },
+                  "editable": {
+                    "description": "",
+                    "name": "editable",
+                    "value": "false"
+                  },
+                  "hasAbout": {
+                    "description": "",
+                    "name": "hasAbout",
+                    "value": "false"
+                  },
+                  "hasHelp": {
+                    "description": "",
+                    "name": "hasHelp",
+                    "value": "false"
+                  },
+                  "hideFromDesktop": {
+                    "description": "",
+                    "name": "hideFromDesktop",
+                    "value": "false"
+                  },
+                  "hideFromMobile": {
+                    "description": "",
+                    "name": "hideFromMobile",
+                    "value": "false"
+                  },
+                  "highlight": {
+                    "description": "",
+                    "name": "highlight",
+                    "value": "false"
+                  },
+                  "iconUrl": {
+                    "description": "",
+                    "name": "iconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/CDITheresePlaniol.svg"
+                  },
+                  "mobileIconUrl": {
+                    "description": "",
+                    "name": "mobileIconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/CDITheresePlaniol.svg"
+                  },
+                  "printable": {
+                    "description": "",
+                    "name": "printable",
+                    "value": "false"
+                  },
+                  "showChrome": {
+                    "description": "",
+                    "name": "showChrome",
+                    "value": "true"
+                  }
+                },
+                "ratingsCount": 0,
+                "state": "PUBLISHED",
+                "title": "Les CDI Th\u00e9r\u00e8se Planiol",
+                "typeId": 4
+              },
+              {
+                "averageRating": 0,
+                "description": "Ressources utiles pour les personnels de l'enseignement agricole                                               documents, documentations, enseignement agricole",
+                "favorite": false,
+                "fname": "LiensUtilAgri",
+                "id": 79,
+                "keywords": [],
+                "name": "Liens UtilAgri",
+                "parameters": {
+                  "alternate": {
+                    "description": "",
+                    "name": "alternate",
+                    "value": "false"
+                  },
+                  "blockImpersonation": {
+                    "description": "",
+                    "name": "blockImpersonation",
+                    "value": "false"
+                  },
+                  "disableDynamicTitle": {
+                    "description": "",
+                    "name": "disableDynamicTitle",
+                    "value": "true"
+                  },
+                  "editable": {
+                    "description": "",
+                    "name": "editable",
+                    "value": "false"
+                  },
+                  "hasAbout": {
+                    "description": "",
+                    "name": "hasAbout",
+                    "value": "false"
+                  },
+                  "hasHelp": {
+                    "description": "",
+                    "name": "hasHelp",
+                    "value": "false"
+                  },
+                  "hideFromDesktop": {
+                    "description": "",
+                    "name": "hideFromDesktop",
+                    "value": "false"
+                  },
+                  "hideFromMobile": {
+                    "description": "",
+                    "name": "hideFromMobile",
+                    "value": "false"
+                  },
+                  "highlight": {
+                    "description": "",
+                    "name": "highlight",
+                    "value": "false"
+                  },
+                  "iconUrl": {
+                    "description": "",
+                    "name": "iconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/LiensUtilAgri.svg"
+                  },
+                  "locale": {
+                    "description": "",
+                    "name": "locale",
+                    "value": "false"
+                  },
+                  "mobileIconUrl": {
+                    "description": "",
+                    "name": "mobileIconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/LiensUtilAgri.svg"
+                  },
+                  "printable": {
+                    "description": "",
+                    "name": "printable",
+                    "value": "false"
+                  },
+                  "secure": {
+                    "description": "",
+                    "name": "secure",
+                    "value": "false"
+                  },
+                  "showChrome": {
+                    "description": "",
+                    "name": "showChrome",
+                    "value": "true"
+                  }
+                },
+                "ratingsCount": 0,
+                "state": "PUBLISHED",
+                "title": "Liens UtilAgri",
+                "typeId": 7
+              },
+              {
+                "averageRating": 0,
+                "description": "Liens utiles pour les CFA                                                                                    documents, documentations, R\u00e9gion Centre-Val de Loire, ressources, aides r\u00e9gionales",
+                "favorite": false,
+                "fname": "liensUtilesCFA",
+                "id": 119,
+                "keywords": [],
+                "name": "Liens utiles CFA",
+                "parameters": {
+                  "alternate": {
+                    "description": "",
+                    "name": "alternate",
+                    "value": "false"
+                  },
+                  "blockImpersonation": {
+                    "description": "",
+                    "name": "blockImpersonation",
+                    "value": "false"
+                  },
+                  "disableDynamicTitle": {
+                    "description": "",
+                    "name": "disableDynamicTitle",
+                    "value": "true"
+                  },
+                  "editable": {
+                    "description": "",
+                    "name": "editable",
+                    "value": "false"
+                  },
+                  "hasAbout": {
+                    "description": "",
+                    "name": "hasAbout",
+                    "value": "false"
+                  },
+                  "hasHelp": {
+                    "description": "",
+                    "name": "hasHelp",
+                    "value": "false"
+                  },
+                  "hideFromDesktop": {
+                    "description": "",
+                    "name": "hideFromDesktop",
+                    "value": "false"
+                  },
+                  "hideFromMobile": {
+                    "description": "",
+                    "name": "hideFromMobile",
+                    "value": "false"
+                  },
+                  "highlight": {
+                    "description": "",
+                    "name": "highlight",
+                    "value": "false"
+                  },
+                  "iconUrl": {
+                    "description": "",
+                    "name": "iconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/liensUtilesCFA.svg"
+                  },
+                  "locale": {
+                    "description": "",
+                    "name": "locale",
+                    "value": "false"
+                  },
+                  "mobileIconUrl": {
+                    "description": "",
+                    "name": "mobileIconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/liensUtilesCFA.svg"
+                  },
+                  "printable": {
+                    "description": "",
+                    "name": "printable",
+                    "value": "false"
+                  },
+                  "secure": {
+                    "description": "",
+                    "name": "secure",
+                    "value": "false"
+                  },
+                  "showChrome": {
+                    "description": "",
+                    "name": "showChrome",
+                    "value": "true"
+                  }
+                },
+                "ratingsCount": 0,
+                "state": "PUBLISHED",
+                "title": "Liens utiles CFA",
+                "typeId": 7
+              },
+              {
+                "averageRating": 0,
+                "description": "Ressources \u00e9ducatives utiles, pr\u00e9sent\u00e9es sous forme de liens                                                 documents, documentations, \u00e9ducation nationale",
+                "favorite": false,
+                "fname": "LiensEdutiles",
+                "id": 78,
+                "keywords": [],
+                "name": "Liens \u00c9dutiles",
+                "parameters": {
+                  "alternate": {
+                    "description": "",
+                    "name": "alternate",
+                    "value": "false"
+                  },
+                  "blockImpersonation": {
+                    "description": "",
+                    "name": "blockImpersonation",
+                    "value": "false"
+                  },
+                  "disableDynamicTitle": {
+                    "description": "",
+                    "name": "disableDynamicTitle",
+                    "value": "true"
+                  },
+                  "editable": {
+                    "description": "",
+                    "name": "editable",
+                    "value": "false"
+                  },
+                  "hasAbout": {
+                    "description": "",
+                    "name": "hasAbout",
+                    "value": "false"
+                  },
+                  "hasHelp": {
+                    "description": "",
+                    "name": "hasHelp",
+                    "value": "false"
+                  },
+                  "hideFromDesktop": {
+                    "description": "",
+                    "name": "hideFromDesktop",
+                    "value": "false"
+                  },
+                  "hideFromMobile": {
+                    "description": "",
+                    "name": "hideFromMobile",
+                    "value": "false"
+                  },
+                  "highlight": {
+                    "description": "",
+                    "name": "highlight",
+                    "value": "false"
+                  },
+                  "iconUrl": {
+                    "description": "",
+                    "name": "iconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/LiensEdutiles.svg"
+                  },
+                  "locale": {
+                    "description": "",
+                    "name": "locale",
+                    "value": "false"
+                  },
+                  "mobileIconUrl": {
+                    "description": "",
+                    "name": "mobileIconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/LiensEdutiles.svg"
+                  },
+                  "printable": {
+                    "description": "",
+                    "name": "printable",
+                    "value": "false"
+                  },
+                  "secure": {
+                    "description": "",
+                    "name": "secure",
+                    "value": "false"
+                  },
+                  "showChrome": {
+                    "description": "",
+                    "name": "showChrome",
+                    "value": "true"
+                  }
+                },
+                "ratingsCount": 0,
+                "state": "PUBLISHED",
+                "title": "Liens \u00c9dutiles",
+                "typeId": 7
+              },
+              {
+                "averageRating": 0,
+                "description": "Acc\u00e8s aux ressources num\u00e9riques mises \u00e0 ma disposition                                                   documents, \u00e9ducatives, scolaires, multim\u00e9dia, vid\u00e9os, manuels, abonnements",
+                "favorite": false,
+                "fname": "RessourcesNumeriques",
+                "id": 91,
+                "keywords": [],
+                "name": "Mes ressources num\u00e9riques",
+                "parameters": {
+                  "alternate": {
+                    "description": "",
+                    "name": "alternate",
+                    "value": "false"
+                  },
+                  "blockImpersonation": {
+                    "description": "",
+                    "name": "blockImpersonation",
+                    "value": "false"
+                  },
+                  "disableDynamicTitle": {
+                    "description": "",
+                    "name": "disableDynamicTitle",
+                    "value": "true"
+                  },
+                  "editable": {
+                    "description": "",
+                    "name": "editable",
+                    "value": "false"
+                  },
+                  "hasAbout": {
+                    "description": "",
+                    "name": "hasAbout",
+                    "value": "false"
+                  },
+                  "hasHelp": {
+                    "description": "",
+                    "name": "hasHelp",
+                    "value": "false"
+                  },
+                  "hideFromDesktop": {
+                    "description": "",
+                    "name": "hideFromDesktop",
+                    "value": "false"
+                  },
+                  "hideFromMobile": {
+                    "description": "",
+                    "name": "hideFromMobile",
+                    "value": "false"
+                  },
+                  "highlight": {
+                    "description": "",
+                    "name": "highlight",
+                    "value": "false"
+                  },
+                  "iconUrl": {
+                    "description": "",
+                    "name": "iconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/Mediacentre.svg"
+                  },
+                  "locale": {
+                    "description": "",
+                    "name": "locale",
+                    "value": "false"
+                  },
+                  "mobileIconUrl": {
+                    "description": "",
+                    "name": "mobileIconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/Mediacentre.svg"
+                  },
+                  "printable": {
+                    "description": "",
+                    "name": "printable",
+                    "value": "false"
+                  },
+                  "secure": {
+                    "description": "",
+                    "name": "secure",
+                    "value": "false"
+                  },
+                  "showChrome": {
+                    "description": "",
+                    "name": "showChrome",
+                    "value": "true"
+                  }
+                },
+                "ratingsCount": 0,
+                "state": "PUBLISHED",
+                "title": "Mes ressources num\u00e9riques",
+                "typeId": 7
+              },
+              {
+                "averageRating": 0,
+                "description": "Acc\u00e8s aux ressources du CDI de l'\u00e9tablissement                                                               centre de documentation, information, biblioth\u00e8que, documentation, livres, scolaires, emprunter, multi-m\u00e9dia, ressources, num\u00e9riques, e-sidoc",
+                "favorite": false,
+                "fname": "MonCDI",
+                "id": 82,
+                "keywords": [],
+                "name": "Mon CDI",
+                "parameters": {
+                  "alternate": {
+                    "description": "",
+                    "name": "alternate",
+                    "value": "false"
+                  },
+                  "alternativeMaximizedLink": {
+                    "description": "",
+                    "name": "alternativeMaximizedLink",
+                    "value": "/portail/api/ExternalURLStats?fname=ESIDOC&service=/esco-apps-redirector/index.php?appli=ESIDOC"
+                  },
+                  "blockImpersonation": {
+                    "description": "",
+                    "name": "blockImpersonation",
+                    "value": "false"
+                  },
+                  "disableDynamicTitle": {
+                    "description": "",
+                    "name": "disableDynamicTitle",
+                    "value": "true"
+                  },
+                  "editable": {
+                    "description": "",
+                    "name": "editable",
+                    "value": "false"
+                  },
+                  "hasAbout": {
+                    "description": "",
+                    "name": "hasAbout",
+                    "value": "false"
+                  },
+                  "hasHelp": {
+                    "description": "",
+                    "name": "hasHelp",
+                    "value": "false"
+                  },
+                  "hideFromDesktop": {
+                    "description": "",
+                    "name": "hideFromDesktop",
+                    "value": "false"
+                  },
+                  "hideFromMobile": {
+                    "description": "",
+                    "name": "hideFromMobile",
+                    "value": "false"
+                  },
+                  "highlight": {
+                    "description": "",
+                    "name": "highlight",
+                    "value": "false"
+                  },
+                  "iconUrl": {
+                    "description": "",
+                    "name": "iconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/MonCDI.svg"
+                  },
+                  "mobileIconUrl": {
+                    "description": "",
+                    "name": "mobileIconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/MonCDI.svg"
+                  },
+                  "printable": {
+                    "description": "",
+                    "name": "printable",
+                    "value": "false"
+                  },
+                  "showChrome": {
+                    "description": "",
+                    "name": "showChrome",
+                    "value": "true"
+                  }
+                },
+                "ratingsCount": 0,
+                "state": "PUBLISHED",
+                "title": "Mon CDI",
+                "typeId": 4
+              },
+              {
+                "averageRating": 0,
+                "description": "Ensemble de ressources num\u00e9riques de diff\u00e9rents \u00e9diteurs, disponibles pour l'utilisateur                      documents, \u00e9ducatives, scolaires, multim\u00e9dia, vid\u00e9os, manuels, abonnements, GAR, gestionnaire acc\u00e8s aux ressources",
+                "favorite": false,
+                "fname": "Mediacentre",
+                "id": 81,
+                "keywords": [],
+                "name": "M\u00e9diacentre",
+                "parameters": {
+                  "alternate": {
+                    "description": "",
+                    "name": "alternate",
+                    "value": "false"
+                  },
+                  "blockImpersonation": {
+                    "description": "",
+                    "name": "blockImpersonation",
+                    "value": "false"
+                  },
+                  "disableDynamicTitle": {
+                    "description": "",
+                    "name": "disableDynamicTitle",
+                    "value": "true"
+                  },
+                  "editable": {
+                    "description": "",
+                    "name": "editable",
+                    "value": "false"
+                  },
+                  "hasAbout": {
+                    "description": "",
+                    "name": "hasAbout",
+                    "value": "false"
+                  },
+                  "hasHelp": {
+                    "description": "",
+                    "name": "hasHelp",
+                    "value": "false"
+                  },
+                  "hideFromDesktop": {
+                    "description": "",
+                    "name": "hideFromDesktop",
+                    "value": "false"
+                  },
+                  "hideFromMobile": {
+                    "description": "",
+                    "name": "hideFromMobile",
+                    "value": "false"
+                  },
+                  "highlight": {
+                    "description": "",
+                    "name": "highlight",
+                    "value": "false"
+                  },
+                  "iconUrl": {
+                    "description": "",
+                    "name": "iconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/Mediacentre.svg"
+                  },
+                  "locale": {
+                    "description": "",
+                    "name": "locale",
+                    "value": "false"
+                  },
+                  "mobileIconUrl": {
+                    "description": "",
+                    "name": "mobileIconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/Mediacentre.svg"
+                  },
+                  "printable": {
+                    "description": "",
+                    "name": "printable",
+                    "value": "false"
+                  },
+                  "secure": {
+                    "description": "",
+                    "name": "secure",
+                    "value": "false"
+                  },
+                  "showChrome": {
+                    "description": "",
+                    "name": "showChrome",
+                    "value": "true"
+                  }
+                },
+                "ratingsCount": 0,
+                "state": "PUBLISHED",
+                "title": "M\u00e9diacentre",
+                "typeId": 7
+              },
+              {
+                "averageRating": 0,
+                "description": "Les ressources disponibles dans le CDI de l'\u00e9tablissement                                                    centre de documentation, information, biblioth\u00e8que, documentation, livres, scolaires, emprunt, emprunter, multi-m\u00e9dia, ressources, num\u00e9riques, PMB",
+                "favorite": false,
+                "fname": "PMB_LesCharmilles",
+                "id": 88,
+                "keywords": [],
+                "name": "Ressources du CDI",
+                "parameters": {
+                  "alternate": {
+                    "description": "",
+                    "name": "alternate",
+                    "value": "false"
+                  },
+                  "alternativeMaximizedLink": {
+                    "description": "",
+                    "name": "alternativeMaximizedLink",
+                    "value": "/portail/api/ExternalURLStats?fname=PMB&service=http://lp-charmilles-chateauroux.tice.ac-orleans-tours.fr/php5/pmb/opac_css/?database=DB_lp_charmilles_chateauroux_PHP5"
+                  },
+                  "blockImpersonation": {
+                    "description": "",
+                    "name": "blockImpersonation",
+                    "value": "true"
+                  },
+                  "disableDynamicTitle": {
+                    "description": "",
+                    "name": "disableDynamicTitle",
+                    "value": "true"
+                  },
+                  "editable": {
+                    "description": "",
+                    "name": "editable",
+                    "value": "false"
+                  },
+                  "hasAbout": {
+                    "description": "",
+                    "name": "hasAbout",
+                    "value": "false"
+                  },
+                  "hasHelp": {
+                    "description": "",
+                    "name": "hasHelp",
+                    "value": "false"
+                  },
+                  "hideFromDesktop": {
+                    "description": "",
+                    "name": "hideFromDesktop",
+                    "value": "false"
+                  },
+                  "hideFromMobile": {
+                    "description": "",
+                    "name": "hideFromMobile",
+                    "value": "false"
+                  },
+                  "highlight": {
+                    "description": "",
+                    "name": "highlight",
+                    "value": "false"
+                  },
+                  "iconUrl": {
+                    "description": "",
+                    "name": "iconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/PMB_LesCharmilles.svg"
+                  },
+                  "mobileIconUrl": {
+                    "description": "",
+                    "name": "mobileIconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/PMB_LesCharmilles.svg"
+                  },
+                  "printable": {
+                    "description": "",
+                    "name": "printable",
+                    "value": "false"
+                  },
+                  "showChrome": {
+                    "description": "",
+                    "name": "showChrome",
+                    "value": "true"
+                  }
+                },
+                "ratingsCount": 0,
+                "state": "PUBLISHED",
+                "title": "Ressources du CDI",
+                "typeId": 4
+              },
+              {
+                "averageRating": 0,
+                "description": "Plate-forme OAE du GIP RECIA, outil collaboratif et de r\u00e9seau social                                         projets, partage, groupes, collaboratif, stockage, ESUP, \u00e9criture collaborative, vid\u00e9os, sons, documents, images, versions, travail collaboratif",
+                "favorite": false,
+                "fname": "OAE_RECIA",
+                "id": 109,
+                "keywords": [],
+                "name": "R\u00e9seau social OAE",
+                "parameters": {
+                  "alternate": {
+                    "description": "",
+                    "name": "alternate",
+                    "value": "false"
+                  },
+                  "alternativeMaximizedLink": {
+                    "description": "",
+                    "name": "alternativeMaximizedLink",
+                    "value": "/portail/api/ExternalURLStats?fname=OAE_RECIA&service=https://oae.giprecia.fr"
+                  },
+                  "blockImpersonation": {
+                    "description": "",
+                    "name": "blockImpersonation",
+                    "value": "true"
+                  },
+                  "editable": {
+                    "description": "",
+                    "name": "editable",
+                    "value": "false"
+                  },
+                  "hasAbout": {
+                    "description": "",
+                    "name": "hasAbout",
+                    "value": "false"
+                  },
+                  "hasHelp": {
+                    "description": "",
+                    "name": "hasHelp",
+                    "value": "false"
+                  },
+                  "hideFromDesktop": {
+                    "description": "",
+                    "name": "hideFromDesktop",
+                    "value": "false"
+                  },
+                  "hideFromMobile": {
+                    "description": "",
+                    "name": "hideFromMobile",
+                    "value": "false"
+                  },
+                  "highlight": {
+                    "description": "",
+                    "name": "highlight",
+                    "value": "false"
+                  },
+                  "iconUrl": {
+                    "description": "",
+                    "name": "iconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/AccesOAE_RECIA.svg"
+                  },
+                  "mobileIconUrl": {
+                    "description": "",
+                    "name": "mobileIconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/AccesOAE_RECIA.svg"
+                  },
+                  "printable": {
+                    "description": "",
+                    "name": "printable",
+                    "value": "false"
+                  },
+                  "showChrome": {
+                    "description": "",
+                    "name": "showChrome",
+                    "value": "true"
+                  }
+                },
+                "ratingsCount": 0,
+                "state": "PUBLISHED",
+                "title": "OAE",
+                "typeId": 6
+              },
+              {
+                "averageRating": 0,
+                "description": "Application ownCloud du GIP RECIA                                                                              stockage, partage, r\u00e9pertoires, fichiers, multim\u00e9dia, vid\u00e9os, sons, images, documents, versions, nextcloud",
+                "favorite": false,
+                "fname": "OwnCloud_RECIA",
+                "id": 86,
+                "keywords": [],
+                "name": "ownCloud du GIP RECIA",
+                "parameters": {
+                  "alternate": {
+                    "description": "",
+                    "name": "alternate",
+                    "value": "false"
+                  },
+                  "alternativeMaximizedLink": {
+                    "description": "",
+                    "name": "alternativeMaximizedLink",
+                    "value": "/portail/api/ExternalURLStats?fname=Owncloud_RECIA&service=https://owncloud.recia.fr/index.php?app=user_cas"
+                  },
+                  "blockImpersonation": {
+                    "description": "",
+                    "name": "blockImpersonation",
+                    "value": "true"
+                  },
+                  "editable": {
+                    "description": "",
+                    "name": "editable",
+                    "value": "false"
+                  },
+                  "hasAbout": {
+                    "description": "",
+                    "name": "hasAbout",
+                    "value": "false"
+                  },
+                  "hasHelp": {
+                    "description": "",
+                    "name": "hasHelp",
+                    "value": "false"
+                  },
+                  "hideFromDesktop": {
+                    "description": "",
+                    "name": "hideFromDesktop",
+                    "value": "false"
+                  },
+                  "hideFromMobile": {
+                    "description": "",
+                    "name": "hideFromMobile",
+                    "value": "false"
+                  },
+                  "highlight": {
+                    "description": "",
+                    "name": "highlight",
+                    "value": "false"
+                  },
+                  "iconUrl": {
+                    "description": "",
+                    "name": "iconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/OwnCloud_RECIA.svg"
+                  },
+                  "locale": {
+                    "description": "",
+                    "name": "locale",
+                    "value": "false"
+                  },
+                  "mobileIconUrl": {
+                    "description": "",
+                    "name": "mobileIconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/OwnCloud_RECIA.svg"
+                  },
+                  "printable": {
+                    "description": "",
+                    "name": "printable",
+                    "value": "false"
+                  },
+                  "secure": {
+                    "description": "",
+                    "name": "secure",
+                    "value": "false"
+                  }
+                },
+                "ratingsCount": 0,
+                "state": "PUBLISHED",
+                "title": "ownCloud",
+                "typeId": 6
+              }
+            ],
+            "subcategories": []
+          },
+          {
+            "description": "Services li\u00e9s au syst\u00e8me d'information",
+            "id": "local.37",
+            "name": "Syst\u00e8me d'information",
+            "portlets": [
+              {
+                "averageRating": 0,
+                "description": "Les derni\u00e8res informations du GIP RECIA pour les administrateurs                                             actualit\u00e9s, ENT, GSI, GIP RECIA, incidents, nouvelles, annonces",
+                "favorite": false,
+                "fname": "ResumeInfosENT",
+                "id": 96,
+                "keywords": [],
+                "name": "Derni\u00e8res informations administrateurs",
+                "parameters": {
+                  "alternate": {
+                    "description": "",
+                    "name": "alternate",
+                    "value": "false"
+                  },
+                  "blockImpersonation": {
+                    "description": "",
+                    "name": "blockImpersonation",
+                    "value": "false"
+                  },
+                  "disableDynamicTitle": {
+                    "description": "",
+                    "name": "disableDynamicTitle",
+                    "value": "true"
+                  },
+                  "editable": {
+                    "description": "",
+                    "name": "editable",
+                    "value": "false"
+                  },
+                  "hasAbout": {
+                    "description": "",
+                    "name": "hasAbout",
+                    "value": "false"
+                  },
+                  "hasHelp": {
+                    "description": "",
+                    "name": "hasHelp",
+                    "value": "false"
+                  },
+                  "hideFromDesktop": {
+                    "description": "",
+                    "name": "hideFromDesktop",
+                    "value": "false"
+                  },
+                  "hideFromMobile": {
+                    "description": "",
+                    "name": "hideFromMobile",
+                    "value": "false"
+                  },
+                  "highlight": {
+                    "description": "",
+                    "name": "highlight",
+                    "value": "false"
+                  },
+                  "iconUrl": {
+                    "description": "",
+                    "name": "iconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/ResumeInfosENT"
+                  },
+                  "locale": {
+                    "description": "",
+                    "name": "locale",
+                    "value": "false"
+                  },
+                  "mobileIconUrl": {
+                    "description": "",
+                    "name": "mobileIconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/ResumeInfosENT"
+                  },
+                  "printable": {
+                    "description": "",
+                    "name": "printable",
+                    "value": "false"
+                  },
+                  "secure": {
+                    "description": "",
+                    "name": "secure",
+                    "value": "false"
+                  },
+                  "showChrome": {
+                    "description": "",
+                    "name": "showChrome",
+                    "value": "true"
+                  }
+                },
+                "ratingsCount": 1,
+                "state": "PUBLISHED",
+                "title": "Derni\u00e8res informations administrateurs",
+                "typeId": 7
+              },
+              {
+                "averageRating": 0,
+                "description": "Documentations de l'ENT \u00e0 destination des administrateurs, directeurs, etc ...                                 administration, administrateur, informations, notices,  portail, applications, services, aide, assistance",
+                "favorite": false,
+                "fname": "DocENT",
+                "id": 54,
+                "keywords": [],
+                "name": "Documentations ENT",
+                "parameters": {
+                  "alternate": {
+                    "description": "",
+                    "name": "alternate",
+                    "value": "false"
+                  },
+                  "blockImpersonation": {
+                    "description": "",
+                    "name": "blockImpersonation",
+                    "value": "false"
+                  },
+                  "disableDynamicTitle": {
+                    "description": "",
+                    "name": "disableDynamicTitle",
+                    "value": "true"
+                  },
+                  "editable": {
+                    "description": "",
+                    "name": "editable",
+                    "value": "false"
+                  },
+                  "hasAbout": {
+                    "description": "",
+                    "name": "hasAbout",
+                    "value": "false"
+                  },
+                  "hasHelp": {
+                    "description": "",
+                    "name": "hasHelp",
+                    "value": "false"
+                  },
+                  "hideFromDesktop": {
+                    "description": "",
+                    "name": "hideFromDesktop",
+                    "value": "false"
+                  },
+                  "hideFromMobile": {
+                    "description": "",
+                    "name": "hideFromMobile",
+                    "value": "false"
+                  },
+                  "highlight": {
+                    "description": "",
+                    "name": "highlight",
+                    "value": "false"
+                  },
+                  "iconUrl": {
+                    "description": "",
+                    "name": "iconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/DocENT.svg"
+                  },
+                  "locale": {
+                    "description": "",
+                    "name": "locale",
+                    "value": "false"
+                  },
+                  "mobileIconUrl": {
+                    "description": "",
+                    "name": "mobileIconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/DocENT.svg"
+                  },
+                  "printable": {
+                    "description": "",
+                    "name": "printable",
+                    "value": "false"
+                  },
+                  "secure": {
+                    "description": "",
+                    "name": "secure",
+                    "value": "false"
+                  },
+                  "showChrome": {
+                    "description": "",
+                    "name": "showChrome",
+                    "value": "true"
+                  }
+                },
+                "ratingsCount": 0,
+                "state": "PUBLISHED",
+                "title": "Documentations ENT",
+                "typeId": 7
+              },
+              {
+                "averageRating": 0,
+                "description": "Gestion des groupes de l'ENT (Grouper)                                                                       administration, administrateur, utilisateurs, classes, niveaux, enseignements, services, droits, applications, \u00e9tablissement, portail",
+                "favorite": false,
+                "fname": "I2Grouper-UI",
+                "id": 74,
+                "keywords": [],
+                "name": "Gestion de groupes Grouper",
+                "parameters": {
+                  "alternate": {
+                    "description": "",
+                    "name": "alternate",
+                    "value": "false"
+                  },
+                  "blockImpersonation": {
+                    "description": "",
+                    "name": "blockImpersonation",
+                    "value": "true"
+                  },
+                  "editable": {
+                    "description": "",
+                    "name": "editable",
+                    "value": "false"
+                  },
+                  "hasAbout": {
+                    "description": "",
+                    "name": "hasAbout",
+                    "value": "false"
+                  },
+                  "hasHelp": {
+                    "description": "",
+                    "name": "hasHelp",
+                    "value": "false"
+                  },
+                  "hideFromDesktop": {
+                    "description": "",
+                    "name": "hideFromDesktop",
+                    "value": "false"
+                  },
+                  "hideFromMobile": {
+                    "description": "",
+                    "name": "hideFromMobile",
+                    "value": "false"
+                  },
+                  "highlight": {
+                    "description": "",
+                    "name": "highlight",
+                    "value": "false"
+                  },
+                  "iconUrl": {
+                    "description": "",
+                    "name": "iconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/I2Grouper-UI.svg"
+                  },
+                  "locale": {
+                    "description": "",
+                    "name": "locale",
+                    "value": "false"
+                  },
+                  "mobileIconUrl": {
+                    "description": "",
+                    "name": "mobileIconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/I2Grouper-UI.svg"
+                  },
+                  "printable": {
+                    "description": "",
+                    "name": "printable",
+                    "value": "false"
+                  },
+                  "secure": {
+                    "description": "",
+                    "name": "secure",
+                    "value": "false"
+                  },
+                  "showChrome": {
+                    "description": "",
+                    "name": "showChrome",
+                    "value": "true"
+                  }
+                },
+                "ratingsCount": 0,
+                "state": "PUBLISHED",
+                "title": "Gestion des groupes",
+                "typeId": 6
+              },
+              {
+                "averageRating": 0,
+                "description": "Gestion des comptes de l'ENT (comptes ENT, comptes locaux, rattachement de comptes externes, compl\u00e9ment sur les comptes \u00e9tablissement, exports, ...) administration, administrateur, mot de passe, activation, r\u00e9initialisation, utilisateurs, d\u00e9blocage",
+                "favorite": true,
+                "fname": "ESCO-GLC",
+                "id": 57,
+                "keywords": [],
+                "name": "Gestion locale des comptes ENT",
+                "parameters": {
+                  "alternate": {
+                    "description": "",
+                    "name": "alternate",
+                    "value": "false"
+                  },
+                  "blockImpersonation": {
+                    "description": "",
+                    "name": "blockImpersonation",
+                    "value": "true"
+                  },
+                  "editable": {
+                    "description": "",
+                    "name": "editable",
+                    "value": "false"
+                  },
+                  "hasAbout": {
+                    "description": "",
+                    "name": "hasAbout",
+                    "value": "false"
+                  },
+                  "hasHelp": {
+                    "description": "",
+                    "name": "hasHelp",
+                    "value": "false"
+                  },
+                  "hideFromDesktop": {
+                    "description": "",
+                    "name": "hideFromDesktop",
+                    "value": "false"
+                  },
+                  "hideFromMobile": {
+                    "description": "",
+                    "name": "hideFromMobile",
+                    "value": "false"
+                  },
+                  "highlight": {
+                    "description": "",
+                    "name": "highlight",
+                    "value": "false"
+                  },
+                  "iconUrl": {
+                    "description": "",
+                    "name": "iconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/ESCO-GLC.svg"
+                  },
+                  "locale": {
+                    "description": "",
+                    "name": "locale",
+                    "value": "false"
+                  },
+                  "mobileIconUrl": {
+                    "description": "",
+                    "name": "mobileIconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/ESCO-GLC.svg"
+                  },
+                  "printable": {
+                    "description": "",
+                    "name": "printable",
+                    "value": "false"
+                  },
+                  "secure": {
+                    "description": "",
+                    "name": "secure",
+                    "value": "false"
+                  },
+                  "showChrome": {
+                    "description": "",
+                    "name": "showChrome",
+                    "value": "true"
+                  }
+                },
+                "ratingsCount": 0,
+                "state": "PUBLISHED",
+                "title": "Gestion des comptes",
+                "typeId": 6
+              },
+              {
+                "averageRating": 0,
+                "description": "Actualit\u00e9s du GIP RECIA \u00e0 destination des admnistrateurs ENT                                                 actualit\u00e9s, ENT, GSI, GIP RECIA, incidents, nouvelles, annonces",
+                "favorite": false,
+                "fname": "AnnoncesRECIA",
+                "id": 47,
+                "keywords": [],
+                "name": "Information administrateurs",
+                "parameters": {
+                  "alternate": {
+                    "description": "",
+                    "name": "alternate",
+                    "value": "false"
+                  },
+                  "blockImpersonation": {
+                    "description": "",
+                    "name": "blockImpersonation",
+                    "value": "false"
+                  },
+                  "disableDynamicTitle": {
+                    "description": "",
+                    "name": "disableDynamicTitle",
+                    "value": "true"
+                  },
+                  "editable": {
+                    "description": "",
+                    "name": "editable",
+                    "value": "false"
+                  },
+                  "hasAbout": {
+                    "description": "",
+                    "name": "hasAbout",
+                    "value": "false"
+                  },
+                  "hasHelp": {
+                    "description": "",
+                    "name": "hasHelp",
+                    "value": "false"
+                  },
+                  "hideFromDesktop": {
+                    "description": "",
+                    "name": "hideFromDesktop",
+                    "value": "false"
+                  },
+                  "hideFromMobile": {
+                    "description": "",
+                    "name": "hideFromMobile",
+                    "value": "false"
+                  },
+                  "highlight": {
+                    "description": "",
+                    "name": "highlight",
+                    "value": "false"
+                  },
+                  "iconUrl": {
+                    "description": "",
+                    "name": "iconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/AnnoncesRECIA.svg"
+                  },
+                  "locale": {
+                    "description": "",
+                    "name": "locale",
+                    "value": "false"
+                  },
+                  "mobileIconUrl": {
+                    "description": "",
+                    "name": "mobileIconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/AnnoncesRECIA.svg"
+                  },
+                  "printable": {
+                    "description": "",
+                    "name": "printable",
+                    "value": "false"
+                  },
+                  "secure": {
+                    "description": "",
+                    "name": "secure",
+                    "value": "false"
+                  },
+                  "showChrome": {
+                    "description": "",
+                    "name": "showChrome",
+                    "value": "true"
+                  }
+                },
+                "ratingsCount": 0,
+                "state": "PUBLISHED",
+                "title": "Information administrateurs",
+                "typeId": 7
+              },
+              {
+                "averageRating": 0,
+                "description": "Liste des logiciels disponibles dans le catalogue OPSI                                                       maintenance, administration, administrateur, informatique, itop, CSL, Correspondant Support Local, assistance, ordinateur, PC",
+                "favorite": false,
+                "fname": "Catalogue_OPSI",
+                "id": 132,
+                "keywords": [],
+                "name": "Logiciels disponibles",
+                "parameters": {
+                  "alternate": {
+                    "description": "",
+                    "name": "alternate",
+                    "value": "false"
+                  },
+                  "alternativeMaximizedLink": {
+                    "description": "",
+                    "name": "alternativeMaximizedLink",
+                    "value": "/portail/api/ExternalURLStats?fname=Catalogue_OPSI&service=https://www.escolan.recia.fr/opsi-catalogue/"
+                  },
+                  "blockImpersonation": {
+                    "description": "",
+                    "name": "blockImpersonation",
+                    "value": "true"
+                  },
+                  "editable": {
+                    "description": "",
+                    "name": "editable",
+                    "value": "false"
+                  },
+                  "hasAbout": {
+                    "description": "",
+                    "name": "hasAbout",
+                    "value": "false"
+                  },
+                  "hasHelp": {
+                    "description": "",
+                    "name": "hasHelp",
+                    "value": "false"
+                  },
+                  "hideFromDesktop": {
+                    "description": "",
+                    "name": "hideFromDesktop",
+                    "value": "false"
+                  },
+                  "hideFromMobile": {
+                    "description": "",
+                    "name": "hideFromMobile",
+                    "value": "false"
+                  },
+                  "highlight": {
+                    "description": "",
+                    "name": "highlight",
+                    "value": "false"
+                  },
+                  "iconUrl": {
+                    "description": "",
+                    "name": "iconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/Catalogue_OPSI.svg"
+                  },
+                  "locale": {
+                    "description": "",
+                    "name": "locale",
+                    "value": "false"
+                  },
+                  "mobileIconUrl": {
+                    "description": "",
+                    "name": "mobileIconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/Catalogue_OPSI.svg"
+                  },
+                  "printable": {
+                    "description": "",
+                    "name": "printable",
+                    "value": "false"
+                  },
+                  "secure": {
+                    "description": "",
+                    "name": "secure",
+                    "value": "false"
+                  },
+                  "showChrome": {
+                    "description": "",
+                    "name": "showChrome",
+                    "value": "true"
+                  }
+                },
+                "ratingsCount": 0,
+                "state": "PUBLISHED",
+                "title": "Logiciels disponibles",
+                "typeId": 6
+              },
+              {
+                "averageRating": 0,
+                "description": "Informations sur le projet de maintenance informatique dans les lyc\u00e9es                                       administration, administrateur, itop, CSL, Correspondant Support Local, assistance, ordinateurs, PC, logiciels",
+                "favorite": false,
+                "fname": "MILycees",
+                "id": 136,
+                "keywords": [],
+                "name": "Maintenance informatique des lyc\u00e9es",
+                "parameters": {
+                  "alternate": {
+                    "description": "",
+                    "name": "alternate",
+                    "value": "false"
+                  },
+                  "blockImpersonation": {
+                    "description": "",
+                    "name": "blockImpersonation",
+                    "value": "true"
+                  },
+                  "chromeStyle": {
+                    "description": "",
+                    "name": "chromeStyle",
+                    "value": "default"
+                  },
+                  "configurable": {
+                    "description": "",
+                    "name": "configurable",
+                    "value": "false"
+                  },
+                  "disableDynamicTitle": {
+                    "description": "",
+                    "name": "disableDynamicTitle",
+                    "value": "true"
+                  },
+                  "disablePortletEvents": {
+                    "description": "",
+                    "name": "disablePortletEvents",
+                    "value": "false"
+                  },
+                  "editable": {
+                    "description": "",
+                    "name": "editable",
+                    "value": "false"
+                  },
+                  "hasAbout": {
+                    "description": "",
+                    "name": "hasAbout",
+                    "value": "false"
+                  },
+                  "hasHelp": {
+                    "description": "",
+                    "name": "hasHelp",
+                    "value": "false"
+                  },
+                  "hideFromDesktop": {
+                    "description": "",
+                    "name": "hideFromDesktop",
+                    "value": "false"
+                  },
+                  "hideFromMobile": {
+                    "description": "",
+                    "name": "hideFromMobile",
+                    "value": "false"
+                  },
+                  "highlight": {
+                    "description": "",
+                    "name": "highlight",
+                    "value": "false"
+                  },
+                  "iconUrl": {
+                    "description": "",
+                    "name": "iconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/MILycees.svg"
+                  },
+                  "mobileIconUrl": {
+                    "description": "",
+                    "name": "mobileIconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/MILycees.svg"
+                  },
+                  "printable": {
+                    "description": "",
+                    "name": "printable",
+                    "value": "false"
+                  },
+                  "showChrome": {
+                    "description": "",
+                    "name": "showChrome",
+                    "value": "true"
+                  }
+                },
+                "ratingsCount": 0,
+                "state": "PUBLISHED",
+                "title": "Maintenance informatique des lyc\u00e9es",
+                "typeId": 4
+              },
+              {
+                "averageRating": 0,
+                "description": "Param\u00e9trage de certains \u00e9l\u00e9ments propres \u00e0 l'\u00e9tablissement pour le portail ENT (nom court, logo)             administration, administrateur, lyc\u00e9e, coll\u00e8ge, CFA, ITS, nom long, personnalisation",
+                "favorite": true,
+                "fname": "ESCO-ParamEtab",
+                "id": 133,
+                "keywords": [],
+                "name": "Param\u00e9trage \u00e9tablissement",
+                "parameters": {
+                  "alternate": {
+                    "description": "",
+                    "name": "alternate",
+                    "value": "false"
+                  },
+                  "blockImpersonation": {
+                    "description": "",
+                    "name": "blockImpersonation",
+                    "value": "true"
+                  },
+                  "chromeStyle": {
+                    "description": "",
+                    "name": "chromeStyle",
+                    "value": "default"
+                  },
+                  "configurable": {
+                    "description": "",
+                    "name": "configurable",
+                    "value": "false"
+                  },
+                  "disableDynamicTitle": {
+                    "description": "",
+                    "name": "disableDynamicTitle",
+                    "value": "true"
+                  },
+                  "disablePortletEvents": {
+                    "description": "",
+                    "name": "disablePortletEvents",
+                    "value": "false"
+                  },
+                  "editable": {
+                    "description": "",
+                    "name": "editable",
+                    "value": "false"
+                  },
+                  "hasAbout": {
+                    "description": "",
+                    "name": "hasAbout",
+                    "value": "false"
+                  },
+                  "hasHelp": {
+                    "description": "",
+                    "name": "hasHelp",
+                    "value": "false"
+                  },
+                  "hideFromDesktop": {
+                    "description": "",
+                    "name": "hideFromDesktop",
+                    "value": "false"
+                  },
+                  "hideFromMobile": {
+                    "description": "",
+                    "name": "hideFromMobile",
+                    "value": "false"
+                  },
+                  "highlight": {
+                    "description": "",
+                    "name": "highlight",
+                    "value": "false"
+                  },
+                  "iconUrl": {
+                    "description": "",
+                    "name": "iconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/ESCO-ParamEtab.svg"
+                  },
+                  "locale": {
+                    "description": "",
+                    "name": "locale",
+                    "value": "false"
+                  },
+                  "mobileIconUrl": {
+                    "description": "",
+                    "name": "mobileIconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/ESCO-ParamEtab.svg"
+                  },
+                  "printable": {
+                    "description": "",
+                    "name": "printable",
+                    "value": "false"
+                  },
+                  "secure": {
+                    "description": "",
+                    "name": "secure",
+                    "value": "false"
+                  },
+                  "showChrome": {
+                    "description": "",
+                    "name": "showChrome",
+                    "value": "true"
+                  }
+                },
+                "ratingsCount": 0,
+                "state": "PUBLISHED",
+                "title": "Param\u00e9trage \u00e9tablissement",
+                "typeId": 6
+              },
+              {
+                "averageRating": 0,
+                "description": "Outil de support du GIP RECIA                                                                                  maintenance, administration, administrateur, CSL, Correspondant Support Local, assistance, ordinateur, PC, demande, ticket, suivi, aide",
+                "favorite": false,
+                "fname": "ITSM",
+                "id": 75,
+                "keywords": [],
+                "name": "Portail des requ\u00eates (iTop)",
+                "parameters": {
+                  "alternate": {
+                    "description": "",
+                    "name": "alternate",
+                    "value": "false"
+                  },
+                  "alternativeMaximizedLink": {
+                    "description": "",
+                    "name": "alternativeMaximizedLink",
+                    "value": "/portail/api/ExternalURLStats?fname=ITSM&service=https://itsm.escolan.recia.fr/pages/UI.php?login_mode=cas"
+                  },
+                  "blockImpersonation": {
+                    "description": "",
+                    "name": "blockImpersonation",
+                    "value": "true"
+                  },
+                  "editable": {
+                    "description": "",
+                    "name": "editable",
+                    "value": "false"
+                  },
+                  "hasAbout": {
+                    "description": "",
+                    "name": "hasAbout",
+                    "value": "false"
+                  },
+                  "hasHelp": {
+                    "description": "",
+                    "name": "hasHelp",
+                    "value": "false"
+                  },
+                  "hideFromDesktop": {
+                    "description": "",
+                    "name": "hideFromDesktop",
+                    "value": "false"
+                  },
+                  "hideFromMobile": {
+                    "description": "",
+                    "name": "hideFromMobile",
+                    "value": "false"
+                  },
+                  "highlight": {
+                    "description": "",
+                    "name": "highlight",
+                    "value": "false"
+                  },
+                  "iconUrl": {
+                    "description": "",
+                    "name": "iconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/ITSM.svg"
+                  },
+                  "locale": {
+                    "description": "",
+                    "name": "locale",
+                    "value": "false"
+                  },
+                  "mobileIconUrl": {
+                    "description": "",
+                    "name": "mobileIconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/ITSM.svg"
+                  },
+                  "printable": {
+                    "description": "",
+                    "name": "printable",
+                    "value": "false"
+                  },
+                  "secure": {
+                    "description": "",
+                    "name": "secure",
+                    "value": "false"
+                  },
+                  "showChrome": {
+                    "description": "",
+                    "name": "showChrome",
+                    "value": "true"
+                  }
+                },
+                "ratingsCount": 0,
+                "state": "PUBLISHED",
+                "title": "Portail des requ\u00eates (iTop)",
+                "typeId": 6
+              }
+            ],
+            "subcategories": []
+          },
+          {
+            "description": "Cat\u00e9gorie parente des portlets appartenants aux tenants. Chaque tenant poss\u00e8de \u00e7a propre cat\u00e9gorie.",
+            "id": "local.20",
+            "name": "Tenant Portlets",
+            "portlets": [
+              {
+                "averageRating": 0,
+                "description": "Instructions to help a new tenant get started",
+                "favorite": false,
+                "fname": "instructions-for-new-tenants",
+                "id": 13,
+                "keywords": [],
+                "name": "Instructions for New Tenants",
+                "parameters": {
+                  "blockImpersonation": {
+                    "description": "",
+                    "name": "blockImpersonation",
+                    "value": "false"
+                  },
+                  "chromeStyle": {
+                    "description": "",
+                    "name": "chromeStyle",
+                    "value": "default"
+                  },
+                  "configurable": {
+                    "description": "",
+                    "name": "configurable",
+                    "value": "true"
+                  },
+                  "disableDynamicTitle": {
+                    "description": "",
+                    "name": "disableDynamicTitle",
+                    "value": "true"
+                  },
+                  "editable": {
+                    "description": "",
+                    "name": "editable",
+                    "value": "false"
+                  },
+                  "hasAbout": {
+                    "description": "",
+                    "name": "hasAbout",
+                    "value": "false"
+                  },
+                  "hasHelp": {
+                    "description": "",
+                    "name": "hasHelp",
+                    "value": "false"
+                  },
+                  "hideFromMobile": {
+                    "description": "",
+                    "name": "hideFromMobile",
+                    "value": "false"
+                  },
+                  "printable": {
+                    "description": "",
+                    "name": "printable",
+                    "value": "false"
+                  }
+                },
+                "ratingsCount": 0,
+                "state": "PUBLISHED",
+                "title": "Instructions for New Tenants",
+                "typeId": 4
+              }
+            ],
+            "subcategories": []
+          },
+          {
+            "description": "Services li\u00e9s \u00e0 la vie professionnelle",
+            "id": "local.40",
+            "name": "Vie professionnelle",
+            "portlets": [
+              {
+                "averageRating": 0,
+                "description": "Messagerie \u00e9lectronique des personnels de l'enseignement agricole                                            courriel, courrier, mail, webmail, \u00e9ducagri, professionnel, poster",
+                "favorite": false,
+                "fname": "CourrielEducagri",
+                "id": 51,
+                "keywords": [],
+                "name": "Courriel \u00c9ducagri",
+                "parameters": {
+                  "alternate": {
+                    "description": "",
+                    "name": "alternate",
+                    "value": "false"
+                  },
+                  "alternativeMaximizedLink": {
+                    "description": "",
+                    "name": "alternativeMaximizedLink",
+                    "value": "/portail/api/ExternalURLStats?fname=CourrielEducagri&service=https://webmail.educagri.fr/"
+                  },
+                  "blockImpersonation": {
+                    "description": "",
+                    "name": "blockImpersonation",
+                    "value": "true"
+                  },
+                  "disableDynamicTitle": {
+                    "description": "",
+                    "name": "disableDynamicTitle",
+                    "value": "true"
+                  },
+                  "editable": {
+                    "description": "",
+                    "name": "editable",
+                    "value": "false"
+                  },
+                  "hasAbout": {
+                    "description": "",
+                    "name": "hasAbout",
+                    "value": "false"
+                  },
+                  "hasHelp": {
+                    "description": "",
+                    "name": "hasHelp",
+                    "value": "false"
+                  },
+                  "hideFromDesktop": {
+                    "description": "",
+                    "name": "hideFromDesktop",
+                    "value": "false"
+                  },
+                  "hideFromMobile": {
+                    "description": "",
+                    "name": "hideFromMobile",
+                    "value": "false"
+                  },
+                  "highlight": {
+                    "description": "",
+                    "name": "highlight",
+                    "value": "false"
+                  },
+                  "iconUrl": {
+                    "description": "",
+                    "name": "iconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/CourrielEducagri.svg"
+                  },
+                  "mobileIconUrl": {
+                    "description": "",
+                    "name": "mobileIconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/CourrielEducagri.svg"
+                  },
+                  "printable": {
+                    "description": "",
+                    "name": "printable",
+                    "value": "false"
+                  },
+                  "showChrome": {
+                    "description": "",
+                    "name": "showChrome",
+                    "value": "true"
+                  }
+                },
+                "ratingsCount": 0,
+                "state": "PUBLISHED",
+                "title": "Courriel \u00c9ducagri",
+                "typeId": 4
+              },
+              {
+                "averageRating": 0,
+                "description": "Messagerie \u00e9lectronique des personnels de l'\u00e9ducation nationale                                                courriel, courrier, mail, webmail, acad\u00e9mique, acad\u00e9mie, professionnel, Orl\u00e9ans, Tours, rectorat",
+                "favorite": false,
+                "fname": "CourrielAcademique",
+                "id": 50,
+                "keywords": [],
+                "name": "Messagerie acad\u00e9mique",
+                "parameters": {
+                  "alternate": {
+                    "description": "",
+                    "name": "alternate",
+                    "value": "false"
+                  },
+                  "alternativeMaximizedLink": {
+                    "description": "",
+                    "name": "alternativeMaximizedLink",
+                    "value": "/portail/api/ExternalURLStats?fname=CourrielAcademique&service=https://extraent.ac-orleans-tours.fr/iwc_frame/"
+                  },
+                  "blockImpersonation": {
+                    "description": "",
+                    "name": "blockImpersonation",
+                    "value": "true"
+                  },
+                  "disableDynamicTitle": {
+                    "description": "",
+                    "name": "disableDynamicTitle",
+                    "value": "true"
+                  },
+                  "editable": {
+                    "description": "",
+                    "name": "editable",
+                    "value": "false"
+                  },
+                  "hasAbout": {
+                    "description": "",
+                    "name": "hasAbout",
+                    "value": "false"
+                  },
+                  "hasHelp": {
+                    "description": "",
+                    "name": "hasHelp",
+                    "value": "false"
+                  },
+                  "hideFromDesktop": {
+                    "description": "",
+                    "name": "hideFromDesktop",
+                    "value": "false"
+                  },
+                  "hideFromMobile": {
+                    "description": "",
+                    "name": "hideFromMobile",
+                    "value": "false"
+                  },
+                  "highlight": {
+                    "description": "",
+                    "name": "highlight",
+                    "value": "false"
+                  },
+                  "iconUrl": {
+                    "description": "",
+                    "name": "iconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/CourrielAcademique.svg"
+                  },
+                  "mobileIconUrl": {
+                    "description": "",
+                    "name": "mobileIconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/CourrielAcademique.svg"
+                  },
+                  "printable": {
+                    "description": "",
+                    "name": "printable",
+                    "value": "false"
+                  },
+                  "showChrome": {
+                    "description": "",
+                    "name": "showChrome",
+                    "value": "true"
+                  }
+                },
+                "ratingsCount": 0,
+                "state": "PUBLISHED",
+                "title": "Messagerie acad\u00e9mique",
+                "typeId": 4
+              },
+              {
+                "averageRating": 0,
+                "description": "Acc\u00e8s \u00e0 SOGo du GIP RECIA - webmail, agenda et contacts                                                      courriel, courrier, \u00e9lectronique, webmail, professionnel, poster",
+                "favorite": false,
+                "fname": "CourrielRECIA",
+                "id": 53,
+                "keywords": [],
+                "name": "Messagerie du GIP RECIA",
+                "parameters": {
+                  "alternate": {
+                    "description": "",
+                    "name": "alternate",
+                    "value": "false"
+                  },
+                  "alternativeMaximizedLink": {
+                    "description": "",
+                    "name": "alternativeMaximizedLink",
+                    "value": "/portail/api/ExternalURLStats?fname=CourrielRECIA&service=https://sogo.recia.fr/"
+                  },
+                  "blockImpersonation": {
+                    "description": "",
+                    "name": "blockImpersonation",
+                    "value": "true"
+                  },
+                  "editable": {
+                    "description": "",
+                    "name": "editable",
+                    "value": "false"
+                  },
+                  "hasAbout": {
+                    "description": "",
+                    "name": "hasAbout",
+                    "value": "false"
+                  },
+                  "hasHelp": {
+                    "description": "",
+                    "name": "hasHelp",
+                    "value": "false"
+                  },
+                  "hideFromDesktop": {
+                    "description": "",
+                    "name": "hideFromDesktop",
+                    "value": "false"
+                  },
+                  "hideFromMobile": {
+                    "description": "",
+                    "name": "hideFromMobile",
+                    "value": "false"
+                  },
+                  "highlight": {
+                    "description": "",
+                    "name": "highlight",
+                    "value": "false"
+                  },
+                  "iconUrl": {
+                    "description": "",
+                    "name": "iconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/CourrielRECIA.svg"
+                  },
+                  "locale": {
+                    "description": "",
+                    "name": "locale",
+                    "value": "false"
+                  },
+                  "mobileIconUrl": {
+                    "description": "",
+                    "name": "mobileIconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/CourrielRECIA.svg"
+                  },
+                  "printable": {
+                    "description": "",
+                    "name": "printable",
+                    "value": "false"
+                  },
+                  "secure": {
+                    "description": "",
+                    "name": "secure",
+                    "value": "false"
+                  },
+                  "showChrome": {
+                    "description": "",
+                    "name": "showChrome",
+                    "value": "true"
+                  }
+                },
+                "ratingsCount": 0,
+                "state": "PUBLISHED",
+                "title": "Messagerie et agenda",
+                "typeId": 6
+              },
+              {
+                "averageRating": 0,
+                "description": "Plateforme eurecia : gestion Adminsitrative et Ressources humaines                                           RTT, vacances, cong\u00e9s pay\u00e9s, absences, temps de travail, d\u00e9placements, frais, demandes, droits, planning, temps, activit\u00e9s, feuilles de temps",
+                "favorite": false,
+                "fname": "eurecia",
+                "id": 117,
+                "keywords": [],
+                "name": "Outils Administratif RH",
+                "parameters": {
+                  "alternate": {
+                    "description": "",
+                    "name": "alternate",
+                    "value": "false"
+                  },
+                  "alternativeMaximizedLink": {
+                    "description": "",
+                    "name": "alternativeMaximizedLink",
+                    "value": "/portail/api/ExternalURLStats?fname=eurecia&service=https://recia.eurecia.com"
+                  },
+                  "blockImpersonation": {
+                    "description": "",
+                    "name": "blockImpersonation",
+                    "value": "true"
+                  },
+                  "disableDynamicTitle": {
+                    "description": "",
+                    "name": "disableDynamicTitle",
+                    "value": "true"
+                  },
+                  "editable": {
+                    "description": "",
+                    "name": "editable",
+                    "value": "false"
+                  },
+                  "hasAbout": {
+                    "description": "",
+                    "name": "hasAbout",
+                    "value": "false"
+                  },
+                  "hasHelp": {
+                    "description": "",
+                    "name": "hasHelp",
+                    "value": "false"
+                  },
+                  "hideFromDesktop": {
+                    "description": "",
+                    "name": "hideFromDesktop",
+                    "value": "false"
+                  },
+                  "hideFromMobile": {
+                    "description": "",
+                    "name": "hideFromMobile",
+                    "value": "false"
+                  },
+                  "highlight": {
+                    "description": "",
+                    "name": "highlight",
+                    "value": "false"
+                  },
+                  "iconUrl": {
+                    "description": "",
+                    "name": "iconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/eurecia.svg"
+                  },
+                  "mobileIconUrl": {
+                    "description": "",
+                    "name": "mobileIconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/eurecia.svg"
+                  },
+                  "printable": {
+                    "description": "",
+                    "name": "printable",
+                    "value": "false"
+                  },
+                  "showChrome": {
+                    "description": "",
+                    "name": "showChrome",
+                    "value": "true"
+                  }
+                },
+                "ratingsCount": 0,
+                "state": "PUBLISHED",
+                "title": "Outils Administratif RH",
+                "typeId": 4
+              },
+              {
+                "averageRating": 0,
+                "description": "Portail acad\u00e9mique ArenA pour les personnels de l'\u00e9ducation nationale                                          acad\u00e9mie, Orl\u00e9ans, Tours, DSI, Catel, rectorat",
+                "favorite": false,
+                "fname": "PortailArenA",
+                "id": 89,
+                "keywords": [],
+                "name": "Portail ArenA",
+                "parameters": {
+                  "alternate": {
+                    "description": "",
+                    "name": "alternate",
+                    "value": "false"
+                  },
+                  "alternativeMaximizedLink": {
+                    "description": "",
+                    "name": "alternativeMaximizedLink",
+                    "value": "/portail/api/ExternalURLStats?fname=PortailArenA&service=https://extrante.ac-orleans-tours.fr/arena/"
+                  },
+                  "blockImpersonation": {
+                    "description": "",
+                    "name": "blockImpersonation",
+                    "value": "true"
+                  },
+                  "disableDynamicTitle": {
+                    "description": "",
+                    "name": "disableDynamicTitle",
+                    "value": "true"
+                  },
+                  "editable": {
+                    "description": "",
+                    "name": "editable",
+                    "value": "false"
+                  },
+                  "hasAbout": {
+                    "description": "",
+                    "name": "hasAbout",
+                    "value": "false"
+                  },
+                  "hasHelp": {
+                    "description": "",
+                    "name": "hasHelp",
+                    "value": "false"
+                  },
+                  "hideFromDesktop": {
+                    "description": "",
+                    "name": "hideFromDesktop",
+                    "value": "false"
+                  },
+                  "hideFromMobile": {
+                    "description": "",
+                    "name": "hideFromMobile",
+                    "value": "false"
+                  },
+                  "highlight": {
+                    "description": "",
+                    "name": "highlight",
+                    "value": "false"
+                  },
+                  "iconUrl": {
+                    "description": "",
+                    "name": "iconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/PortailArenA.svg"
+                  },
+                  "mobileIconUrl": {
+                    "description": "",
+                    "name": "mobileIconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/PortailArenA.svg"
+                  },
+                  "printable": {
+                    "description": "",
+                    "name": "printable",
+                    "value": "false"
+                  },
+                  "showChrome": {
+                    "description": "",
+                    "name": "showChrome",
+                    "value": "true"
+                  }
+                },
+                "ratingsCount": 0,
+                "state": "PUBLISHED",
+                "title": "Portail ArenA",
+                "typeId": 6
+              }
+            ],
+            "subcategories": []
+          },
+          {
+            "description": "Services li\u00e9s \u00e0 la vie scolaire",
+            "id": "local.38",
+            "name": "Vie scolaire",
+            "portlets": [
+              {
+                "averageRating": 0,
+                "description": "Cahier de texte num\u00e9rique                                                                                    devoirs, s\u00e9ances, emplois du temps, s\u00e9quences, mati\u00e8res, cours, travail \u00e0 faire, devoirs \u00e0 faire, suivi",
+                "favorite": false,
+                "fname": "CahierTexte",
+                "id": 49,
+                "keywords": [],
+                "name": "Cahier de texte",
+                "parameters": {
+                  "alternate": {
+                    "description": "",
+                    "name": "alternate",
+                    "value": "false"
+                  },
+                  "blockImpersonation": {
+                    "description": "",
+                    "name": "blockImpersonation",
+                    "value": "true"
+                  },
+                  "editable": {
+                    "description": "",
+                    "name": "editable",
+                    "value": "false"
+                  },
+                  "hasAbout": {
+                    "description": "",
+                    "name": "hasAbout",
+                    "value": "false"
+                  },
+                  "hasHelp": {
+                    "description": "",
+                    "name": "hasHelp",
+                    "value": "false"
+                  },
+                  "hideFromDesktop": {
+                    "description": "",
+                    "name": "hideFromDesktop",
+                    "value": "false"
+                  },
+                  "hideFromMobile": {
+                    "description": "",
+                    "name": "hideFromMobile",
+                    "value": "false"
+                  },
+                  "highlight": {
+                    "description": "",
+                    "name": "highlight",
+                    "value": "false"
+                  },
+                  "iconUrl": {
+                    "description": "",
+                    "name": "iconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/CahierTexte.svg"
+                  },
+                  "locale": {
+                    "description": "",
+                    "name": "locale",
+                    "value": "false"
+                  },
+                  "mobileIconUrl": {
+                    "description": "",
+                    "name": "mobileIconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/CahierTexte.svg"
+                  },
+                  "printable": {
+                    "description": "",
+                    "name": "printable",
+                    "value": "false"
+                  },
+                  "secure": {
+                    "description": "",
+                    "name": "secure",
+                    "value": "false"
+                  },
+                  "showChrome": {
+                    "description": "",
+                    "name": "showChrome",
+                    "value": "true"
+                  }
+                },
+                "ratingsCount": 0,
+                "state": "PUBLISHED",
+                "title": "Cahier de texte",
+                "typeId": 6
+              },
+              {
+                "averageRating": 0,
+                "description": "Les documents mis \u00e0 disposition par l'\u00e9tablissement                                                            lyc\u00e9e, coll\u00e8ge, CFA, ITS, formulaires, notes, compte-rendus, notices, r\u00e9glements",
+                "favorite": false,
+                "fname": "DocumentsEtab",
+                "id": 55,
+                "keywords": [],
+                "name": "Documents de l'\u00e9tablissement",
+                "parameters": {
+                  "alternate": {
+                    "description": "",
+                    "name": "alternate",
+                    "value": "false"
+                  },
+                  "blockImpersonation": {
+                    "description": "",
+                    "name": "blockImpersonation",
+                    "value": "false"
+                  },
+                  "disableDynamicTitle": {
+                    "description": "",
+                    "name": "disableDynamicTitle",
+                    "value": "true"
+                  },
+                  "editable": {
+                    "description": "",
+                    "name": "editable",
+                    "value": "false"
+                  },
+                  "hasAbout": {
+                    "description": "",
+                    "name": "hasAbout",
+                    "value": "false"
+                  },
+                  "hasHelp": {
+                    "description": "",
+                    "name": "hasHelp",
+                    "value": "false"
+                  },
+                  "hideFromDesktop": {
+                    "description": "",
+                    "name": "hideFromDesktop",
+                    "value": "false"
+                  },
+                  "hideFromMobile": {
+                    "description": "",
+                    "name": "hideFromMobile",
+                    "value": "false"
+                  },
+                  "highlight": {
+                    "description": "",
+                    "name": "highlight",
+                    "value": "false"
+                  },
+                  "iconUrl": {
+                    "description": "",
+                    "name": "iconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/DocumentsEtab.svg"
+                  },
+                  "locale": {
+                    "description": "",
+                    "name": "locale",
+                    "value": "false"
+                  },
+                  "mobileIconUrl": {
+                    "description": "",
+                    "name": "mobileIconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/DocumentsEtab.svg"
+                  },
+                  "printable": {
+                    "description": "",
+                    "name": "printable",
+                    "value": "false"
+                  },
+                  "secure": {
+                    "description": "",
+                    "name": "secure",
+                    "value": "false"
+                  },
+                  "showChrome": {
+                    "description": "",
+                    "name": "showChrome",
+                    "value": "true"
+                  }
+                },
+                "ratingsCount": 0,
+                "state": "PUBLISHED",
+                "title": "Documents de l'\u00e9tablissement",
+                "typeId": 7
+              },
+              {
+                "averageRating": 0,
+                "description": "Acc\u00e8s \u00e0 l'emploi du temps de l'\u00e9tablissement                                                                   emplois du temps, scolarit\u00e9, vie scolaire, classes, groupes, mati\u00e8res",
+                "favorite": false,
+                "fname": "EDT",
+                "id": 56,
+                "keywords": [],
+                "name": "EDT",
+                "parameters": {
+                  "alternate": {
+                    "description": "",
+                    "name": "alternate",
+                    "value": "false"
+                  },
+                  "alternativeMaximizedLink": {
+                    "description": "",
+                    "name": "alternativeMaximizedLink",
+                    "value": "/portail/api/ExternalURLStats?fname=EDT&service=/esco-apps-redirector/index.php?appli=EDT"
+                  },
+                  "blockImpersonation": {
+                    "description": "",
+                    "name": "blockImpersonation",
+                    "value": "true"
+                  },
+                  "editable": {
+                    "description": "",
+                    "name": "editable",
+                    "value": "false"
+                  },
+                  "hasAbout": {
+                    "description": "",
+                    "name": "hasAbout",
+                    "value": "false"
+                  },
+                  "hasHelp": {
+                    "description": "",
+                    "name": "hasHelp",
+                    "value": "false"
+                  },
+                  "hideFromDesktop": {
+                    "description": "",
+                    "name": "hideFromDesktop",
+                    "value": "false"
+                  },
+                  "hideFromMobile": {
+                    "description": "",
+                    "name": "hideFromMobile",
+                    "value": "false"
+                  },
+                  "highlight": {
+                    "description": "",
+                    "name": "highlight",
+                    "value": "false"
+                  },
+                  "iconUrl": {
+                    "description": "",
+                    "name": "iconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/EDT.svg"
+                  },
+                  "locale": {
+                    "description": "",
+                    "name": "locale",
+                    "value": "false"
+                  },
+                  "mobileIconUrl": {
+                    "description": "",
+                    "name": "mobileIconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/EDT.svg"
+                  },
+                  "printable": {
+                    "description": "",
+                    "name": "printable",
+                    "value": "false"
+                  },
+                  "secure": {
+                    "description": "",
+                    "name": "secure",
+                    "value": "false"
+                  },
+                  "showChrome": {
+                    "description": "",
+                    "name": "showChrome",
+                    "value": "true"
+                  }
+                },
+                "ratingsCount": 0,
+                "state": "PUBLISHED",
+                "title": "Emplois du temps",
+                "typeId": 6
+              },
+              {
+                "averageRating": 0,
+                "description": "Outils et ressources p\u00e9dagogiques, suivis de projets et actualit\u00e9s du CFA de la Ville de Tours               vie scolaire, apprentissage, p\u00e9dagogie",
+                "favorite": false,
+                "fname": "EchoSpheres",
+                "id": 59,
+                "keywords": [],
+                "name": "EchoSph\u00e8res",
+                "parameters": {
+                  "alternate": {
+                    "description": "",
+                    "name": "alternate",
+                    "value": "false"
+                  },
+                  "alternativeMaximizedLink": {
+                    "description": "",
+                    "name": "alternativeMaximizedLink",
+                    "value": "https://www.cfa-tours.fr/CAS/index.php"
+                  },
+                  "blockImpersonation": {
+                    "description": "",
+                    "name": "blockImpersonation",
+                    "value": "true"
+                  },
+                  "disableDynamicTitle": {
+                    "description": "",
+                    "name": "disableDynamicTitle",
+                    "value": "true"
+                  },
+                  "editable": {
+                    "description": "",
+                    "name": "editable",
+                    "value": "false"
+                  },
+                  "hasAbout": {
+                    "description": "",
+                    "name": "hasAbout",
+                    "value": "false"
+                  },
+                  "hasHelp": {
+                    "description": "",
+                    "name": "hasHelp",
+                    "value": "false"
+                  },
+                  "hideFromDesktop": {
+                    "description": "",
+                    "name": "hideFromDesktop",
+                    "value": "false"
+                  },
+                  "hideFromMobile": {
+                    "description": "",
+                    "name": "hideFromMobile",
+                    "value": "false"
+                  },
+                  "highlight": {
+                    "description": "",
+                    "name": "highlight",
+                    "value": "false"
+                  },
+                  "iconUrl": {
+                    "description": "",
+                    "name": "iconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/EchoSpheres.svg"
+                  },
+                  "locale": {
+                    "description": "",
+                    "name": "locale",
+                    "value": "false"
+                  },
+                  "mobileIconUrl": {
+                    "description": "",
+                    "name": "mobileIconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/EchoSpheres.svg"
+                  },
+                  "printable": {
+                    "description": "",
+                    "name": "printable",
+                    "value": "false"
+                  },
+                  "secure": {
+                    "description": "",
+                    "name": "secure",
+                    "value": "false"
+                  },
+                  "showChrome": {
+                    "description": "",
+                    "name": "showChrome",
+                    "value": "true"
+                  }
+                },
+                "ratingsCount": 0,
+                "state": "PUBLISHED",
+                "title": "EchoSph\u00e8res",
+                "typeId": 6
+              },
+              {
+                "averageRating": 0,
+                "description": "Acc\u00e8s \u00e0 l'espace Vie Scolaire de l'\u00e9tablissement                                                             Pronote, cahier de texte, emploi du temps, suivi, scolarit\u00e9, notes, absences, contr\u00f4les, saisies, consultation, bulletins, conseil de classe",
+                "favorite": false,
+                "fname": "VieScolaire",
+                "id": 107,
+                "keywords": [],
+                "name": "Espace Vie Scolaire",
+                "parameters": {
+                  "alternate": {
+                    "description": "",
+                    "name": "alternate",
+                    "value": "false"
+                  },
+                  "alternativeMaximizedLink": {
+                    "description": "",
+                    "name": "alternativeMaximizedLink",
+                    "value": "/portail/api/ExternalURLStats?fname=VieScolaire&service=/esco-apps-redirector/index.php?appli=VIESCOLAIRE"
+                  },
+                  "blockImpersonation": {
+                    "description": "",
+                    "name": "blockImpersonation",
+                    "value": "true"
+                  },
+                  "editable": {
+                    "description": "",
+                    "name": "editable",
+                    "value": "false"
+                  },
+                  "hasAbout": {
+                    "description": "",
+                    "name": "hasAbout",
+                    "value": "false"
+                  },
+                  "hasHelp": {
+                    "description": "",
+                    "name": "hasHelp",
+                    "value": "false"
+                  },
+                  "hideFromDesktop": {
+                    "description": "",
+                    "name": "hideFromDesktop",
+                    "value": "false"
+                  },
+                  "hideFromMobile": {
+                    "description": "",
+                    "name": "hideFromMobile",
+                    "value": "false"
+                  },
+                  "highlight": {
+                    "description": "",
+                    "name": "highlight",
+                    "value": "false"
+                  },
+                  "iconUrl": {
+                    "description": "",
+                    "name": "iconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/VieScolaire.svg"
+                  },
+                  "locale": {
+                    "description": "",
+                    "name": "locale",
+                    "value": "false"
+                  },
+                  "mobileIconUrl": {
+                    "description": "",
+                    "name": "mobileIconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/VieScolaire.svg"
+                  },
+                  "printable": {
+                    "description": "",
+                    "name": "printable",
+                    "value": "false"
+                  },
+                  "secure": {
+                    "description": "",
+                    "name": "secure",
+                    "value": "false"
+                  },
+                  "showChrome": {
+                    "description": "",
+                    "name": "showChrome",
+                    "value": "true"
+                  }
+                },
+                "ratingsCount": 0,
+                "state": "PUBLISHED",
+                "title": "Espace Vie Scolaire",
+                "typeId": 6
+              },
+              {
+                "averageRating": 0,
+                "description": "Livret Electronique d'Apprentissage                                                                          suivi, alternance, parcours, entreprises, ma\u00eetres de stage, ma\u00eetres d'apprentissage, comp\u00e9tences",
+                "favorite": false,
+                "fname": "LEA",
+                "id": 76,
+                "keywords": [],
+                "name": "Livret \u00c9lectronique d'Apprentissage",
+                "parameters": {
+                  "alternate": {
+                    "description": "",
+                    "name": "alternate",
+                    "value": "false"
+                  },
+                  "blockImpersonation": {
+                    "description": "",
+                    "name": "blockImpersonation",
+                    "value": "true"
+                  },
+                  "editable": {
+                    "description": "",
+                    "name": "editable",
+                    "value": "false"
+                  },
+                  "hasAbout": {
+                    "description": "",
+                    "name": "hasAbout",
+                    "value": "false"
+                  },
+                  "hasHelp": {
+                    "description": "",
+                    "name": "hasHelp",
+                    "value": "false"
+                  },
+                  "hideFromDesktop": {
+                    "description": "",
+                    "name": "hideFromDesktop",
+                    "value": "false"
+                  },
+                  "hideFromMobile": {
+                    "description": "",
+                    "name": "hideFromMobile",
+                    "value": "false"
+                  },
+                  "highlight": {
+                    "description": "",
+                    "name": "highlight",
+                    "value": "false"
+                  },
+                  "iconUrl": {
+                    "description": "",
+                    "name": "iconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/LEA.svg"
+                  },
+                  "locale": {
+                    "description": "",
+                    "name": "locale",
+                    "value": "false"
+                  },
+                  "mobileIconUrl": {
+                    "description": "",
+                    "name": "mobileIconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/LEA.svg"
+                  },
+                  "printable": {
+                    "description": "",
+                    "name": "printable",
+                    "value": "false"
+                  },
+                  "secure": {
+                    "description": "",
+                    "name": "secure",
+                    "value": "false"
+                  },
+                  "showChrome": {
+                    "description": "",
+                    "name": "showChrome",
+                    "value": "true"
+                  }
+                },
+                "ratingsCount": 0,
+                "state": "PUBLISHED",
+                "title": "Livret \u00c9lectronique d'Apprentissage",
+                "typeId": 6
+              },
+              {
+                "averageRating": 0,
+                "description": "Rapport d'execution de l'extraction Wincfa/Ypareo                                                              erreurs, administration, administrateur, Ymag, suivi, alimentation ENT",
+                "favorite": false,
+                "fname": "YmagLog",
+                "id": 108,
+                "keywords": [],
+                "name": "Rapport d'erreurs Ypar\u00e9o",
+                "parameters": {
+                  "blockImpersonation": {
+                    "description": "",
+                    "name": "blockImpersonation",
+                    "value": "true"
+                  },
+                  "editable": {
+                    "description": "",
+                    "name": "editable",
+                    "value": "false"
+                  },
+                  "hasAbout": {
+                    "description": "",
+                    "name": "hasAbout",
+                    "value": "false"
+                  },
+                  "hasHelp": {
+                    "description": "",
+                    "name": "hasHelp",
+                    "value": "false"
+                  },
+                  "hideFromDesktop": {
+                    "description": "",
+                    "name": "hideFromDesktop",
+                    "value": "false"
+                  },
+                  "hideFromMobile": {
+                    "description": "",
+                    "name": "hideFromMobile",
+                    "value": "false"
+                  },
+                  "highlight": {
+                    "description": "",
+                    "name": "highlight",
+                    "value": "false"
+                  },
+                  "iconUrl": {
+                    "description": "",
+                    "name": "iconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/YmagLog.svg"
+                  },
+                  "locale": {
+                    "description": "",
+                    "name": "locale",
+                    "value": "false"
+                  },
+                  "mobileIconUrl": {
+                    "description": "",
+                    "name": "mobileIconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/YmagLog.svg"
+                  },
+                  "printable": {
+                    "description": "",
+                    "name": "printable",
+                    "value": "false"
+                  },
+                  "secure": {
+                    "description": "",
+                    "name": "secure",
+                    "value": "false"
+                  }
+                },
+                "ratingsCount": 0,
+                "state": "PUBLISHED",
+                "title": "Rapport d'erreurs Ypar\u00e9o",
+                "typeId": 6
+              },
+              {
+                "averageRating": 0,
+                "description": "Vie scolaire (saisie des absences) de SIECLE pour les personnels de l'\u00c9ducation Nationale                      suivi, scolarit\u00e9, notes, contr\u00f4les, saisies, consultation, enseignant, bulletins de notes, acad\u00e9mie, acad\u00e9mique, Orl\u00e9ans, Tours, rectorat",
+                "favorite": false,
+                "fname": "SiecleVieScolaire",
+                "id": 102,
+                "keywords": [],
+                "name": "SIECLE Vie scolaire",
+                "parameters": {
+                  "alternate": {
+                    "description": "",
+                    "name": "alternate",
+                    "value": "false"
+                  },
+                  "alternativeMaximizedLink": {
+                    "description": "",
+                    "name": "alternativeMaximizedLink",
+                    "value": "/portail/api/ExternalURLStats?fname=SiecleVieScolaire&service=https://extraent.ac-orleans-tours.fr/viescolaire/"
+                  },
+                  "blockImpersonation": {
+                    "description": "",
+                    "name": "blockImpersonation",
+                    "value": "true"
+                  },
+                  "editable": {
+                    "description": "",
+                    "name": "editable",
+                    "value": "false"
+                  },
+                  "hasAbout": {
+                    "description": "",
+                    "name": "hasAbout",
+                    "value": "false"
+                  },
+                  "hasHelp": {
+                    "description": "",
+                    "name": "hasHelp",
+                    "value": "false"
+                  },
+                  "hideFromDesktop": {
+                    "description": "",
+                    "name": "hideFromDesktop",
+                    "value": "false"
+                  },
+                  "hideFromMobile": {
+                    "description": "",
+                    "name": "hideFromMobile",
+                    "value": "false"
+                  },
+                  "highlight": {
+                    "description": "",
+                    "name": "highlight",
+                    "value": "false"
+                  },
+                  "iconUrl": {
+                    "description": "",
+                    "name": "iconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/SiecleVieScolaire.svg"
+                  },
+                  "locale": {
+                    "description": "",
+                    "name": "locale",
+                    "value": "false"
+                  },
+                  "mobileIconUrl": {
+                    "description": "",
+                    "name": "mobileIconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/SiecleVieScolaire.svg"
+                  },
+                  "printable": {
+                    "description": "",
+                    "name": "printable",
+                    "value": "false"
+                  },
+                  "secure": {
+                    "description": "",
+                    "name": "secure",
+                    "value": "false"
+                  },
+                  "showChrome": {
+                    "description": "",
+                    "name": "showChrome",
+                    "value": "true"
+                  }
+                },
+                "ratingsCount": 0,
+                "state": "PUBLISHED",
+                "title": "SIECLE Vie scolaire",
+                "typeId": 6
+              },
+              {
+                "averageRating": 0,
+                "description": "Sconet Notes pour les responsables d'\u00e9tablissement de l'\u00c9ducation Nationale                                    suivi, scolarit\u00e9, notes, contr\u00f4les, saisies, consultation, enseignant, bulletins de notes, acad\u00e9mie, acad\u00e9mique, Orl\u00e9ans, Tours, rectorat",
+                "favorite": false,
+                "fname": "SconetNotes_chefetab",
+                "id": 99,
+                "keywords": [],
+                "name": "Sconet notes : Chef d'\u00e9tablissement",
+                "parameters": {
+                  "alternate": {
+                    "description": "",
+                    "name": "alternate",
+                    "value": "false"
+                  },
+                  "alternativeMaximizedLink": {
+                    "description": "",
+                    "name": "alternativeMaximizedLink",
+                    "value": "/portail/api/ExternalURLStats?fname=SconetNotes_chefetab&service=https://extraent.ac-orleans-tours.fr/sconetnotes/index.jsp"
+                  },
+                  "blockImpersonation": {
+                    "description": "",
+                    "name": "blockImpersonation",
+                    "value": "true"
+                  },
+                  "editable": {
+                    "description": "",
+                    "name": "editable",
+                    "value": "false"
+                  },
+                  "hasAbout": {
+                    "description": "",
+                    "name": "hasAbout",
+                    "value": "false"
+                  },
+                  "hasHelp": {
+                    "description": "",
+                    "name": "hasHelp",
+                    "value": "false"
+                  },
+                  "hideFromDesktop": {
+                    "description": "",
+                    "name": "hideFromDesktop",
+                    "value": "false"
+                  },
+                  "hideFromMobile": {
+                    "description": "",
+                    "name": "hideFromMobile",
+                    "value": "false"
+                  },
+                  "highlight": {
+                    "description": "",
+                    "name": "highlight",
+                    "value": "false"
+                  },
+                  "iconUrl": {
+                    "description": "",
+                    "name": "iconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/SconetNotes_chefetab.svg"
+                  },
+                  "locale": {
+                    "description": "",
+                    "name": "locale",
+                    "value": "false"
+                  },
+                  "mobileIconUrl": {
+                    "description": "",
+                    "name": "mobileIconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/SconetNotes_chefetab.svg"
+                  },
+                  "printable": {
+                    "description": "",
+                    "name": "printable",
+                    "value": "false"
+                  },
+                  "secure": {
+                    "description": "",
+                    "name": "secure",
+                    "value": "false"
+                  },
+                  "showChrome": {
+                    "description": "",
+                    "name": "showChrome",
+                    "value": "true"
+                  }
+                },
+                "ratingsCount": 0,
+                "state": "PUBLISHED",
+                "title": "Notes : Chef d'\u00e9tablissement",
+                "typeId": 6
+              },
+              {
+                "averageRating": 0,
+                "description": "Fiches p\u00e9dagogiques de Sconet pour les personnels de l'\u00c9ducation Nationale                                     suivi, scolarit\u00e9, notes, contr\u00f4les, saisies, consultation, enseignant, bulletins de notes, acad\u00e9mie, acad\u00e9mique, Orl\u00e9ans, Tours, rectorat",
+                "favorite": false,
+                "fname": "SconetNotes_peda",
+                "id": 100,
+                "keywords": [],
+                "name": "Sconet notes : fiche p\u00e9dagogique",
+                "parameters": {
+                  "alternate": {
+                    "description": "",
+                    "name": "alternate",
+                    "value": "false"
+                  },
+                  "alternativeMaximizedLink": {
+                    "description": "",
+                    "name": "alternativeMaximizedLink",
+                    "value": "/portail/api/ExternalURLStats?fname=SconetNotes_peda&service=https://extraent.ac-orleans-tours.fr/sconetnotesped/index.jsp"
+                  },
+                  "blockImpersonation": {
+                    "description": "",
+                    "name": "blockImpersonation",
+                    "value": "true"
+                  },
+                  "editable": {
+                    "description": "",
+                    "name": "editable",
+                    "value": "false"
+                  },
+                  "hasAbout": {
+                    "description": "",
+                    "name": "hasAbout",
+                    "value": "false"
+                  },
+                  "hasHelp": {
+                    "description": "",
+                    "name": "hasHelp",
+                    "value": "false"
+                  },
+                  "hideFromDesktop": {
+                    "description": "",
+                    "name": "hideFromDesktop",
+                    "value": "false"
+                  },
+                  "hideFromMobile": {
+                    "description": "",
+                    "name": "hideFromMobile",
+                    "value": "false"
+                  },
+                  "highlight": {
+                    "description": "",
+                    "name": "highlight",
+                    "value": "false"
+                  },
+                  "iconUrl": {
+                    "description": "",
+                    "name": "iconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/SconetNotes_peda.svg"
+                  },
+                  "locale": {
+                    "description": "",
+                    "name": "locale",
+                    "value": "false"
+                  },
+                  "mobileIconUrl": {
+                    "description": "",
+                    "name": "mobileIconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/SconetNotes_peda.svg"
+                  },
+                  "printable": {
+                    "description": "",
+                    "name": "printable",
+                    "value": "false"
+                  },
+                  "secure": {
+                    "description": "",
+                    "name": "secure",
+                    "value": "false"
+                  },
+                  "showChrome": {
+                    "description": "",
+                    "name": "showChrome",
+                    "value": "true"
+                  }
+                },
+                "ratingsCount": 0,
+                "state": "PUBLISHED",
+                "title": "Notes : fiche p\u00e9dagogique",
+                "typeId": 6
+              },
+              {
+                "averageRating": 0,
+                "description": "Sconet Notes pour les enseignants de l'\u00c9ducation Nationale                                                     suivi, scolarit\u00e9, notes, contr\u00f4les, saisies, consultation, enseignant, bulletins de notes, acad\u00e9mie, acad\u00e9mique, Orl\u00e9ans, Tours, rectorat",
+                "favorite": false,
+                "fname": "SconetNotes",
+                "id": 98,
+                "keywords": [],
+                "name": "Sconet notes : saisie des notes enseignant",
+                "parameters": {
+                  "alternate": {
+                    "description": "",
+                    "name": "alternate",
+                    "value": "false"
+                  },
+                  "alternativeMaximizedLink": {
+                    "description": "",
+                    "name": "alternativeMaximizedLink",
+                    "value": "/portail/api/ExternalURLStats?fname=SconetNotes&service=https://extraent.ac-orleans-tours.fr/sconetnotesens/index.jsp"
+                  },
+                  "blockImpersonation": {
+                    "description": "",
+                    "name": "blockImpersonation",
+                    "value": "true"
+                  },
+                  "editable": {
+                    "description": "",
+                    "name": "editable",
+                    "value": "false"
+                  },
+                  "hasAbout": {
+                    "description": "",
+                    "name": "hasAbout",
+                    "value": "false"
+                  },
+                  "hasHelp": {
+                    "description": "",
+                    "name": "hasHelp",
+                    "value": "false"
+                  },
+                  "hideFromDesktop": {
+                    "description": "",
+                    "name": "hideFromDesktop",
+                    "value": "false"
+                  },
+                  "hideFromMobile": {
+                    "description": "",
+                    "name": "hideFromMobile",
+                    "value": "false"
+                  },
+                  "highlight": {
+                    "description": "",
+                    "name": "highlight",
+                    "value": "false"
+                  },
+                  "iconUrl": {
+                    "description": "",
+                    "name": "iconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/SconetNotes.svg"
+                  },
+                  "locale": {
+                    "description": "",
+                    "name": "locale",
+                    "value": "false"
+                  },
+                  "mobileIconUrl": {
+                    "description": "",
+                    "name": "mobileIconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/SconetNotes.svg"
+                  },
+                  "printable": {
+                    "description": "",
+                    "name": "printable",
+                    "value": "false"
+                  },
+                  "secure": {
+                    "description": "",
+                    "name": "secure",
+                    "value": "false"
+                  },
+                  "showChrome": {
+                    "description": "",
+                    "name": "showChrome",
+                    "value": "true"
+                  }
+                },
+                "ratingsCount": 0,
+                "state": "PUBLISHED",
+                "title": "Saisie des notes",
+                "typeId": 6
+              },
+              {
+                "averageRating": 0,
+                "description": "Sconet Notes - vie scolaire pour les personnels de l'\u00c9ducation Nationale                                     suivi, scolarit\u00e9, notes, contr\u00f4les, saisies, consultation, enseignant, bulletins de notes, acad\u00e9mie, acad\u00e9mique, Orl\u00e9ans, Tours, rectorat",
+                "favorite": false,
+                "fname": "SconetNotes_viesco",
+                "id": 101,
+                "keywords": [],
+                "name": "Sconet notes : vie scolaire",
+                "parameters": {
+                  "alternate": {
+                    "description": "",
+                    "name": "alternate",
+                    "value": "false"
+                  },
+                  "alternativeMaximizedLink": {
+                    "description": "",
+                    "name": "alternativeMaximizedLink",
+                    "value": "/portail/api/ExternalURLStats?fname=SconetNotes_viesco&service=https://extraent.ac-orleans-tours.fr/sconetnotesvisco/index.jsp"
+                  },
+                  "blockImpersonation": {
+                    "description": "",
+                    "name": "blockImpersonation",
+                    "value": "true"
+                  },
+                  "editable": {
+                    "description": "",
+                    "name": "editable",
+                    "value": "false"
+                  },
+                  "hasAbout": {
+                    "description": "",
+                    "name": "hasAbout",
+                    "value": "false"
+                  },
+                  "hasHelp": {
+                    "description": "",
+                    "name": "hasHelp",
+                    "value": "false"
+                  },
+                  "hideFromDesktop": {
+                    "description": "",
+                    "name": "hideFromDesktop",
+                    "value": "false"
+                  },
+                  "hideFromMobile": {
+                    "description": "",
+                    "name": "hideFromMobile",
+                    "value": "false"
+                  },
+                  "highlight": {
+                    "description": "",
+                    "name": "highlight",
+                    "value": "false"
+                  },
+                  "iconUrl": {
+                    "description": "",
+                    "name": "iconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/SconetNotes_viesco.svg"
+                  },
+                  "locale": {
+                    "description": "",
+                    "name": "locale",
+                    "value": "false"
+                  },
+                  "mobileIconUrl": {
+                    "description": "",
+                    "name": "mobileIconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/SconetNotes_viesco.svg"
+                  },
+                  "printable": {
+                    "description": "",
+                    "name": "printable",
+                    "value": "false"
+                  },
+                  "secure": {
+                    "description": "",
+                    "name": "secure",
+                    "value": "false"
+                  },
+                  "showChrome": {
+                    "description": "",
+                    "name": "showChrome",
+                    "value": "true"
+                  }
+                },
+                "ratingsCount": 0,
+                "state": "PUBLISHED",
+                "title": "Notes : vie scolaire",
+                "typeId": 6
+              },
+              {
+                "averageRating": 0,
+                "description": "T\u00e9l\u00e9services de l'acad\u00e9mie d'Orl\u00e9ans-Tours                                                                   si\u00e8cle, sconet, cahier de texte, emploi du temps, suivi, scolarit\u00e9, notes, absences, contr\u00f4les, consultation, conseil de classe, acad\u00e9mique",
+                "favorite": false,
+                "fname": "Teleservices",
+                "id": 105,
+                "keywords": [],
+                "name": "T\u00e9l\u00e9services",
+                "parameters": {
+                  "alternate": {
+                    "description": "",
+                    "name": "alternate",
+                    "value": "false"
+                  },
+                  "alternativeMaximizedLink": {
+                    "description": "",
+                    "name": "alternativeMaximizedLink",
+                    "value": "/portail/api/ExternalURLStats?fname=Teleservices&service=https://portail-famille.ac-orleans-tours.fr"
+                  },
+                  "blockImpersonation": {
+                    "description": "",
+                    "name": "blockImpersonation",
+                    "value": "true"
+                  },
+                  "disableDynamicTitle": {
+                    "description": "",
+                    "name": "disableDynamicTitle",
+                    "value": "true"
+                  },
+                  "editable": {
+                    "description": "",
+                    "name": "editable",
+                    "value": "false"
+                  },
+                  "hasAbout": {
+                    "description": "",
+                    "name": "hasAbout",
+                    "value": "false"
+                  },
+                  "hasHelp": {
+                    "description": "",
+                    "name": "hasHelp",
+                    "value": "false"
+                  },
+                  "hideFromDesktop": {
+                    "description": "",
+                    "name": "hideFromDesktop",
+                    "value": "false"
+                  },
+                  "hideFromMobile": {
+                    "description": "",
+                    "name": "hideFromMobile",
+                    "value": "false"
+                  },
+                  "highlight": {
+                    "description": "",
+                    "name": "highlight",
+                    "value": "false"
+                  },
+                  "iconUrl": {
+                    "description": "",
+                    "name": "iconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/Teleservices.svg"
+                  },
+                  "locale": {
+                    "description": "",
+                    "name": "locale",
+                    "value": "false"
+                  },
+                  "mobileIconUrl": {
+                    "description": "",
+                    "name": "mobileIconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/Teleservices.svg"
+                  },
+                  "printable": {
+                    "description": "",
+                    "name": "printable",
+                    "value": "false"
+                  },
+                  "secure": {
+                    "description": "",
+                    "name": "secure",
+                    "value": "false"
+                  },
+                  "showChrome": {
+                    "description": "",
+                    "name": "showChrome",
+                    "value": "true"
+                  }
+                },
+                "ratingsCount": 0,
+                "state": "PUBLISHED",
+                "title": "T\u00e9l\u00e9services",
+                "typeId": 6
+              },
+              {
+                "averageRating": 0,
+                "description": "Informations sur la vie \u00e9tudiante \u00e0 l'ITS de Tours                                                           \u00e9tudiants, apprenti, social, informations, formations, h\u00e9bergement, bourses, aides, assistance",
+                "favorite": false,
+                "fname": "ITS-Tours_VieEtudiante",
+                "id": 134,
+                "keywords": [],
+                "name": "Vie \u00e9tudiante \u00e0 l'ITS",
+                "parameters": {
+                  "alternate": {
+                    "description": "",
+                    "name": "alternate",
+                    "value": "false"
+                  },
+                  "blockImpersonation": {
+                    "description": "",
+                    "name": "blockImpersonation",
+                    "value": "false"
+                  },
+                  "chromeStyle": {
+                    "description": "",
+                    "name": "chromeStyle",
+                    "value": "default"
+                  },
+                  "configurable": {
+                    "description": "",
+                    "name": "configurable",
+                    "value": "false"
+                  },
+                  "disableDynamicTitle": {
+                    "description": "",
+                    "name": "disableDynamicTitle",
+                    "value": "true"
+                  },
+                  "disablePortletEvents": {
+                    "description": "",
+                    "name": "disablePortletEvents",
+                    "value": "false"
+                  },
+                  "editable": {
+                    "description": "",
+                    "name": "editable",
+                    "value": "false"
+                  },
+                  "hasAbout": {
+                    "description": "",
+                    "name": "hasAbout",
+                    "value": "false"
+                  },
+                  "hasHelp": {
+                    "description": "",
+                    "name": "hasHelp",
+                    "value": "false"
+                  },
+                  "hideFromDesktop": {
+                    "description": "",
+                    "name": "hideFromDesktop",
+                    "value": "false"
+                  },
+                  "hideFromMobile": {
+                    "description": "",
+                    "name": "hideFromMobile",
+                    "value": "false"
+                  },
+                  "highlight": {
+                    "description": "",
+                    "name": "highlight",
+                    "value": "false"
+                  },
+                  "iconUrl": {
+                    "description": "",
+                    "name": "iconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/ItsTours_VieEtudiante.svg"
+                  },
+                  "mobileIconUrl": {
+                    "description": "",
+                    "name": "mobileIconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/ItsTours_VieEtudiante.svg"
+                  },
+                  "printable": {
+                    "description": "",
+                    "name": "printable",
+                    "value": "false"
+                  },
+                  "showChrome": {
+                    "description": "",
+                    "name": "showChrome",
+                    "value": "true"
+                  }
+                },
+                "ratingsCount": 0,
+                "state": "PUBLISHED",
+                "title": "Vie \u00e9tudiante \u00e0 l'ITS",
+                "typeId": 4
+              },
+              {
+                "averageRating": 0,
+                "description": "Acc\u00e8s au portail web Ypar\u00e9o                                                                                  Ymag, suivi, alternance, emploi du temps, scolarit\u00e9, notes, absences, contr\u00f4les, saisies, calendrier, consultation, bulletins, conseil de classe",
+                "favorite": false,
+                "fname": "Ypareo",
+                "id": 111,
+                "keywords": [],
+                "name": "Ypar\u00e9o",
+                "parameters": {
+                  "alternate": {
+                    "description": "",
+                    "name": "alternate",
+                    "value": "false"
+                  },
+                  "alternativeMaximizedLink": {
+                    "description": "",
+                    "name": "alternativeMaximizedLink",
+                    "value": "/portail/api/ExternalURLStats?fname=Ypareo&service=/esco-apps-redirector/index.php?appli=YPAREO"
+                  },
+                  "blockImpersonation": {
+                    "description": "",
+                    "name": "blockImpersonation",
+                    "value": "true"
+                  },
+                  "editable": {
+                    "description": "",
+                    "name": "editable",
+                    "value": "false"
+                  },
+                  "hasAbout": {
+                    "description": "",
+                    "name": "hasAbout",
+                    "value": "false"
+                  },
+                  "hasHelp": {
+                    "description": "",
+                    "name": "hasHelp",
+                    "value": "false"
+                  },
+                  "hideFromDesktop": {
+                    "description": "",
+                    "name": "hideFromDesktop",
+                    "value": "false"
+                  },
+                  "hideFromMobile": {
+                    "description": "",
+                    "name": "hideFromMobile",
+                    "value": "false"
+                  },
+                  "highlight": {
+                    "description": "",
+                    "name": "highlight",
+                    "value": "false"
+                  },
+                  "iconUrl": {
+                    "description": "",
+                    "name": "iconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/Ypareo.svg"
+                  },
+                  "locale": {
+                    "description": "",
+                    "name": "locale",
+                    "value": "false"
+                  },
+                  "mobileIconUrl": {
+                    "description": "",
+                    "name": "mobileIconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/Ypareo.svg"
+                  },
+                  "printable": {
+                    "description": "",
+                    "name": "printable",
+                    "value": "false"
+                  },
+                  "secure": {
+                    "description": "",
+                    "name": "secure",
+                    "value": "false"
+                  }
+                },
+                "ratingsCount": 0,
+                "state": "PUBLISHED",
+                "title": "Suivi administratif",
+                "typeId": 6
+              }
+            ],
+            "subcategories": []
+          },
+          {
+            "description": "Services li\u00e9s \u00e0 la vie de l'\u00e9tablissement",
+            "id": "local.39",
+            "name": "Vie \u00e9tablissement - outils",
+            "portlets": [
+              {
+                "averageRating": 0,
+                "description": "Les actualit\u00e9s propos\u00e9es par l'\u00e9tablissement                                                                 lyc\u00e9e, coll\u00e8ge, CFA, ITS, nouvelles, annonces",
+                "favorite": false,
+                "fname": "ActualitesEtab",
+                "id": 43,
+                "keywords": [],
+                "name": "Actualit\u00e9s de l'\u00e9tablissement",
+                "parameters": {
+                  "alternate": {
+                    "description": "",
+                    "name": "alternate",
+                    "value": "false"
+                  },
+                  "blockImpersonation": {
+                    "description": "",
+                    "name": "blockImpersonation",
+                    "value": "false"
+                  },
+                  "disableDynamicTitle": {
+                    "description": "",
+                    "name": "disableDynamicTitle",
+                    "value": "true"
+                  },
+                  "editable": {
+                    "description": "",
+                    "name": "editable",
+                    "value": "false"
+                  },
+                  "hasAbout": {
+                    "description": "",
+                    "name": "hasAbout",
+                    "value": "false"
+                  },
+                  "hasHelp": {
+                    "description": "",
+                    "name": "hasHelp",
+                    "value": "false"
+                  },
+                  "hideFromDesktop": {
+                    "description": "",
+                    "name": "hideFromDesktop",
+                    "value": "false"
+                  },
+                  "hideFromMobile": {
+                    "description": "",
+                    "name": "hideFromMobile",
+                    "value": "false"
+                  },
+                  "highlight": {
+                    "description": "",
+                    "name": "highlight",
+                    "value": "false"
+                  },
+                  "iconUrl": {
+                    "description": "",
+                    "name": "iconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/ActualitesEtab.svg"
+                  },
+                  "locale": {
+                    "description": "",
+                    "name": "locale",
+                    "value": "false"
+                  },
+                  "mobileIconUrl": {
+                    "description": "",
+                    "name": "mobileIconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/ActualitesEtab.svg"
+                  },
+                  "printable": {
+                    "description": "",
+                    "name": "printable",
+                    "value": "false"
+                  },
+                  "secure": {
+                    "description": "",
+                    "name": "secure",
+                    "value": "false"
+                  },
+                  "showChrome": {
+                    "description": "",
+                    "name": "showChrome",
+                    "value": "true"
+                  }
+                },
+                "ratingsCount": 0,
+                "state": "PUBLISHED",
+                "title": "Actualit\u00e9s de l'\u00e9tablissement",
+                "typeId": 7
+              },
+              {
+                "averageRating": 0,
+                "description": "Administration des listes de diffusion de l'\u00e9tablissement                                                    courriel, courrier, \u00e9lectronique, mail, diffusion, diffuser, administrateur, administrer, administrateur",
+                "favorite": false,
+                "fname": "AdminListesDiffusion",
+                "id": 45,
+                "keywords": [],
+                "name": "Administration des listes de diffusion",
+                "parameters": {
+                  "alternate": {
+                    "description": "",
+                    "name": "alternate",
+                    "value": "false"
+                  },
+                  "blockImpersonation": {
+                    "description": "",
+                    "name": "blockImpersonation",
+                    "value": "false"
+                  },
+                  "disableDynamicTitle": {
+                    "description": "",
+                    "name": "disableDynamicTitle",
+                    "value": "true"
+                  },
+                  "editable": {
+                    "description": "",
+                    "name": "editable",
+                    "value": "false"
+                  },
+                  "hasAbout": {
+                    "description": "",
+                    "name": "hasAbout",
+                    "value": "false"
+                  },
+                  "hasHelp": {
+                    "description": "",
+                    "name": "hasHelp",
+                    "value": "false"
+                  },
+                  "hideFromDesktop": {
+                    "description": "",
+                    "name": "hideFromDesktop",
+                    "value": "false"
+                  },
+                  "hideFromMobile": {
+                    "description": "",
+                    "name": "hideFromMobile",
+                    "value": "false"
+                  },
+                  "highlight": {
+                    "description": "",
+                    "name": "highlight",
+                    "value": "false"
+                  },
+                  "iconUrl": {
+                    "description": "",
+                    "name": "iconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/AdminListesDiffusion.svg"
+                  },
+                  "locale": {
+                    "description": "",
+                    "name": "locale",
+                    "value": "false"
+                  },
+                  "mobileIconUrl": {
+                    "description": "",
+                    "name": "mobileIconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/AdminListesDiffusion.svg"
+                  },
+                  "printable": {
+                    "description": "",
+                    "name": "printable",
+                    "value": "false"
+                  },
+                  "secure": {
+                    "description": "",
+                    "name": "secure",
+                    "value": "false"
+                  },
+                  "showChrome": {
+                    "description": "",
+                    "name": "showChrome",
+                    "value": "true"
+                  }
+                },
+                "ratingsCount": 0,
+                "state": "PUBLISHED",
+                "title": "Administration des listes de diffusion",
+                "typeId": 7
+              },
+              {
+                "averageRating": 0,
+                "description": "Agenda personnel et partag\u00e9                                                                                  agenda, emplois du temps, \u00e9v\u00e9nements, rendez-vous",
+                "favorite": false,
+                "fname": "AgendaKronolith",
+                "id": 46,
+                "keywords": [],
+                "name": "Agenda Kronolith",
+                "parameters": {
+                  "alternate": {
+                    "description": "",
+                    "name": "alternate",
+                    "value": "false"
+                  },
+                  "alternativeMaximizedLink": {
+                    "description": "",
+                    "name": "alternativeMaximizedLink",
+                    "value": "/portail/api/ExternalURLStats?fname=Agenda&service=/horde_cfa/kronolith"
+                  },
+                  "blockImpersonation": {
+                    "description": "",
+                    "name": "blockImpersonation",
+                    "value": "true"
+                  },
+                  "editable": {
+                    "description": "",
+                    "name": "editable",
+                    "value": "false"
+                  },
+                  "hasAbout": {
+                    "description": "",
+                    "name": "hasAbout",
+                    "value": "false"
+                  },
+                  "hasHelp": {
+                    "description": "",
+                    "name": "hasHelp",
+                    "value": "false"
+                  },
+                  "hideFromDesktop": {
+                    "description": "",
+                    "name": "hideFromDesktop",
+                    "value": "false"
+                  },
+                  "hideFromMobile": {
+                    "description": "",
+                    "name": "hideFromMobile",
+                    "value": "false"
+                  },
+                  "highlight": {
+                    "description": "",
+                    "name": "highlight",
+                    "value": "false"
+                  },
+                  "iconUrl": {
+                    "description": "",
+                    "name": "iconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/AgendaKronolith.svg"
+                  },
+                  "locale": {
+                    "description": "",
+                    "name": "locale",
+                    "value": "false"
+                  },
+                  "mobileIconUrl": {
+                    "description": "",
+                    "name": "mobileIconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/AgendaKronolith.svg"
+                  },
+                  "printable": {
+                    "description": "",
+                    "name": "printable",
+                    "value": "false"
+                  },
+                  "secure": {
+                    "description": "",
+                    "name": "secure",
+                    "value": "false"
+                  },
+                  "showChrome": {
+                    "description": "",
+                    "name": "showChrome",
+                    "value": "true"
+                  }
+                },
+                "ratingsCount": 0,
+                "state": "PUBLISHED",
+                "title": "Agenda",
+                "typeId": 6
+              },
+              {
+                "averageRating": 0,
+                "description": "Les derni\u00e8res actualit\u00e9s propos\u00e9es par l'\u00e9tablissement                                                       lyc\u00e9e, coll\u00e8ge, CFA, ITS, nouvelles, annonces",
+                "favorite": false,
+                "fname": "ResumeActualitesEtab",
+                "id": 94,
+                "keywords": [],
+                "name": "Derni\u00e8res actualit\u00e9s de l'\u00e9tablissement",
+                "parameters": {
+                  "alternate": {
+                    "description": "",
+                    "name": "alternate",
+                    "value": "false"
+                  },
+                  "blockImpersonation": {
+                    "description": "",
+                    "name": "blockImpersonation",
+                    "value": "false"
+                  },
+                  "disableDynamicTitle": {
+                    "description": "",
+                    "name": "disableDynamicTitle",
+                    "value": "true"
+                  },
+                  "editable": {
+                    "description": "",
+                    "name": "editable",
+                    "value": "false"
+                  },
+                  "hasAbout": {
+                    "description": "",
+                    "name": "hasAbout",
+                    "value": "false"
+                  },
+                  "hasHelp": {
+                    "description": "",
+                    "name": "hasHelp",
+                    "value": "false"
+                  },
+                  "hideFromDesktop": {
+                    "description": "",
+                    "name": "hideFromDesktop",
+                    "value": "false"
+                  },
+                  "hideFromMobile": {
+                    "description": "",
+                    "name": "hideFromMobile",
+                    "value": "false"
+                  },
+                  "highlight": {
+                    "description": "",
+                    "name": "highlight",
+                    "value": "false"
+                  },
+                  "iconUrl": {
+                    "description": "",
+                    "name": "iconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/ResumeActualitesEtab.svg"
+                  },
+                  "locale": {
+                    "description": "",
+                    "name": "locale",
+                    "value": "false"
+                  },
+                  "mobileIconUrl": {
+                    "description": "",
+                    "name": "mobileIconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/ResumeActualitesEtab.svg"
+                  },
+                  "printable": {
+                    "description": "",
+                    "name": "printable",
+                    "value": "false"
+                  },
+                  "secure": {
+                    "description": "",
+                    "name": "secure",
+                    "value": "false"
+                  },
+                  "showChrome": {
+                    "description": "",
+                    "name": "showChrome",
+                    "value": "true"
+                  }
+                },
+                "ratingsCount": 1,
+                "state": "PUBLISHED",
+                "title": "Derni\u00e8res actualit\u00e9s de l'\u00e9tablissement",
+                "typeId": 7
+              },
+              {
+                "averageRating": 0,
+                "description": "Les documents mis \u00e0 disposition par l'\u00e9tablissement                                                            lyc\u00e9e, coll\u00e8ge, CFA, ITS, formulaires, notes, compte-rendus, notices, r\u00e9glements",
+                "favorite": false,
+                "fname": "DocumentsEtab",
+                "id": 55,
+                "keywords": [],
+                "name": "Documents de l'\u00e9tablissement",
+                "parameters": {
+                  "alternate": {
+                    "description": "",
+                    "name": "alternate",
+                    "value": "false"
+                  },
+                  "blockImpersonation": {
+                    "description": "",
+                    "name": "blockImpersonation",
+                    "value": "false"
+                  },
+                  "disableDynamicTitle": {
+                    "description": "",
+                    "name": "disableDynamicTitle",
+                    "value": "true"
+                  },
+                  "editable": {
+                    "description": "",
+                    "name": "editable",
+                    "value": "false"
+                  },
+                  "hasAbout": {
+                    "description": "",
+                    "name": "hasAbout",
+                    "value": "false"
+                  },
+                  "hasHelp": {
+                    "description": "",
+                    "name": "hasHelp",
+                    "value": "false"
+                  },
+                  "hideFromDesktop": {
+                    "description": "",
+                    "name": "hideFromDesktop",
+                    "value": "false"
+                  },
+                  "hideFromMobile": {
+                    "description": "",
+                    "name": "hideFromMobile",
+                    "value": "false"
+                  },
+                  "highlight": {
+                    "description": "",
+                    "name": "highlight",
+                    "value": "false"
+                  },
+                  "iconUrl": {
+                    "description": "",
+                    "name": "iconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/DocumentsEtab.svg"
+                  },
+                  "locale": {
+                    "description": "",
+                    "name": "locale",
+                    "value": "false"
+                  },
+                  "mobileIconUrl": {
+                    "description": "",
+                    "name": "mobileIconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/DocumentsEtab.svg"
+                  },
+                  "printable": {
+                    "description": "",
+                    "name": "printable",
+                    "value": "false"
+                  },
+                  "secure": {
+                    "description": "",
+                    "name": "secure",
+                    "value": "false"
+                  },
+                  "showChrome": {
+                    "description": "",
+                    "name": "showChrome",
+                    "value": "true"
+                  }
+                },
+                "ratingsCount": 0,
+                "state": "PUBLISHED",
+                "title": "Documents de l'\u00e9tablissement",
+                "typeId": 7
+              },
+              {
+                "averageRating": 0,
+                "description": "Acc\u00e8s \u00e0 l'emploi du temps de l'\u00e9tablissement                                                                   emplois du temps, scolarit\u00e9, vie scolaire, classes, groupes, mati\u00e8res",
+                "favorite": false,
+                "fname": "EDT",
+                "id": 56,
+                "keywords": [],
+                "name": "EDT",
+                "parameters": {
+                  "alternate": {
+                    "description": "",
+                    "name": "alternate",
+                    "value": "false"
+                  },
+                  "alternativeMaximizedLink": {
+                    "description": "",
+                    "name": "alternativeMaximizedLink",
+                    "value": "/portail/api/ExternalURLStats?fname=EDT&service=/esco-apps-redirector/index.php?appli=EDT"
+                  },
+                  "blockImpersonation": {
+                    "description": "",
+                    "name": "blockImpersonation",
+                    "value": "true"
+                  },
+                  "editable": {
+                    "description": "",
+                    "name": "editable",
+                    "value": "false"
+                  },
+                  "hasAbout": {
+                    "description": "",
+                    "name": "hasAbout",
+                    "value": "false"
+                  },
+                  "hasHelp": {
+                    "description": "",
+                    "name": "hasHelp",
+                    "value": "false"
+                  },
+                  "hideFromDesktop": {
+                    "description": "",
+                    "name": "hideFromDesktop",
+                    "value": "false"
+                  },
+                  "hideFromMobile": {
+                    "description": "",
+                    "name": "hideFromMobile",
+                    "value": "false"
+                  },
+                  "highlight": {
+                    "description": "",
+                    "name": "highlight",
+                    "value": "false"
+                  },
+                  "iconUrl": {
+                    "description": "",
+                    "name": "iconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/EDT.svg"
+                  },
+                  "locale": {
+                    "description": "",
+                    "name": "locale",
+                    "value": "false"
+                  },
+                  "mobileIconUrl": {
+                    "description": "",
+                    "name": "mobileIconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/EDT.svg"
+                  },
+                  "printable": {
+                    "description": "",
+                    "name": "printable",
+                    "value": "false"
+                  },
+                  "secure": {
+                    "description": "",
+                    "name": "secure",
+                    "value": "false"
+                  },
+                  "showChrome": {
+                    "description": "",
+                    "name": "showChrome",
+                    "value": "true"
+                  }
+                },
+                "ratingsCount": 0,
+                "state": "PUBLISHED",
+                "title": "Emplois du temps",
+                "typeId": 6
+              },
+              {
+                "averageRating": 0,
+                "description": "Outils et ressources p\u00e9dagogiques, suivis de projets et actualit\u00e9s du CFA de la Ville de Tours               vie scolaire, apprentissage, p\u00e9dagogie",
+                "favorite": false,
+                "fname": "EchoSpheres",
+                "id": 59,
+                "keywords": [],
+                "name": "EchoSph\u00e8res",
+                "parameters": {
+                  "alternate": {
+                    "description": "",
+                    "name": "alternate",
+                    "value": "false"
+                  },
+                  "alternativeMaximizedLink": {
+                    "description": "",
+                    "name": "alternativeMaximizedLink",
+                    "value": "https://www.cfa-tours.fr/CAS/index.php"
+                  },
+                  "blockImpersonation": {
+                    "description": "",
+                    "name": "blockImpersonation",
+                    "value": "true"
+                  },
+                  "disableDynamicTitle": {
+                    "description": "",
+                    "name": "disableDynamicTitle",
+                    "value": "true"
+                  },
+                  "editable": {
+                    "description": "",
+                    "name": "editable",
+                    "value": "false"
+                  },
+                  "hasAbout": {
+                    "description": "",
+                    "name": "hasAbout",
+                    "value": "false"
+                  },
+                  "hasHelp": {
+                    "description": "",
+                    "name": "hasHelp",
+                    "value": "false"
+                  },
+                  "hideFromDesktop": {
+                    "description": "",
+                    "name": "hideFromDesktop",
+                    "value": "false"
+                  },
+                  "hideFromMobile": {
+                    "description": "",
+                    "name": "hideFromMobile",
+                    "value": "false"
+                  },
+                  "highlight": {
+                    "description": "",
+                    "name": "highlight",
+                    "value": "false"
+                  },
+                  "iconUrl": {
+                    "description": "",
+                    "name": "iconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/EchoSpheres.svg"
+                  },
+                  "locale": {
+                    "description": "",
+                    "name": "locale",
+                    "value": "false"
+                  },
+                  "mobileIconUrl": {
+                    "description": "",
+                    "name": "mobileIconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/EchoSpheres.svg"
+                  },
+                  "printable": {
+                    "description": "",
+                    "name": "printable",
+                    "value": "false"
+                  },
+                  "secure": {
+                    "description": "",
+                    "name": "secure",
+                    "value": "false"
+                  },
+                  "showChrome": {
+                    "description": "",
+                    "name": "showChrome",
+                    "value": "true"
+                  }
+                },
+                "ratingsCount": 0,
+                "state": "PUBLISHED",
+                "title": "EchoSph\u00e8res",
+                "typeId": 6
+              },
+              {
+                "averageRating": 0,
+                "description": "Gestion et r\u00e9servation de ressources                                                                         mat\u00e9riel, \u00e9tablissement, salles, mat\u00e9riel, v\u00e9hicules, \u00e9quipement",
+                "favorite": false,
+                "fname": "GRR2_CFA",
+                "id": 70,
+                "keywords": [],
+                "name": "GRR CFA",
+                "parameters": {
+                  "alternate": {
+                    "description": "",
+                    "name": "alternate",
+                    "value": "false"
+                  },
+                  "blockImpersonation": {
+                    "description": "",
+                    "name": "blockImpersonation",
+                    "value": "true"
+                  },
+                  "editable": {
+                    "description": "",
+                    "name": "editable",
+                    "value": "false"
+                  },
+                  "hasAbout": {
+                    "description": "",
+                    "name": "hasAbout",
+                    "value": "false"
+                  },
+                  "hasHelp": {
+                    "description": "",
+                    "name": "hasHelp",
+                    "value": "false"
+                  },
+                  "hideFromDesktop": {
+                    "description": "",
+                    "name": "hideFromDesktop",
+                    "value": "false"
+                  },
+                  "hideFromMobile": {
+                    "description": "",
+                    "name": "hideFromMobile",
+                    "value": "false"
+                  },
+                  "highlight": {
+                    "description": "",
+                    "name": "highlight",
+                    "value": "false"
+                  },
+                  "iconUrl": {
+                    "description": "",
+                    "name": "iconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/GRR2_CFA.svg"
+                  },
+                  "locale": {
+                    "description": "",
+                    "name": "locale",
+                    "value": "false"
+                  },
+                  "mobileIconUrl": {
+                    "description": "",
+                    "name": "mobileIconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/GRR2_CFA.svg"
+                  },
+                  "printable": {
+                    "description": "",
+                    "name": "printable",
+                    "value": "false"
+                  },
+                  "secure": {
+                    "description": "",
+                    "name": "secure",
+                    "value": "false"
+                  },
+                  "showChrome": {
+                    "description": "",
+                    "name": "showChrome",
+                    "value": "true"
+                  }
+                },
+                "ratingsCount": 0,
+                "state": "PUBLISHED",
+                "title": "Gestion et r\u00e9servation de ressources",
+                "typeId": 6
+              },
+              {
+                "averageRating": 0,
+                "description": "Gestion et r\u00e9servation de ressources pour les \u00e9l\u00e8ves du lyc\u00e9e Jacques coeur                                  mat\u00e9riel, \u00e9tablissement, salles, mat\u00e9riel, v\u00e9hicules, \u00e9quipement",
+                "favorite": false,
+                "fname": "GRR_JCoeurEleves",
+                "id": 72,
+                "keywords": [],
+                "name": "GRR des \u00e9l\u00e8ves",
+                "parameters": {
+                  "alternate": {
+                    "description": "",
+                    "name": "alternate",
+                    "value": "false"
+                  },
+                  "blockImpersonation": {
+                    "description": "",
+                    "name": "blockImpersonation",
+                    "value": "true"
+                  },
+                  "editable": {
+                    "description": "",
+                    "name": "editable",
+                    "value": "false"
+                  },
+                  "hasAbout": {
+                    "description": "",
+                    "name": "hasAbout",
+                    "value": "false"
+                  },
+                  "hasHelp": {
+                    "description": "",
+                    "name": "hasHelp",
+                    "value": "false"
+                  },
+                  "hideFromDesktop": {
+                    "description": "",
+                    "name": "hideFromDesktop",
+                    "value": "false"
+                  },
+                  "hideFromMobile": {
+                    "description": "",
+                    "name": "hideFromMobile",
+                    "value": "false"
+                  },
+                  "highlight": {
+                    "description": "",
+                    "name": "highlight",
+                    "value": "false"
+                  },
+                  "iconUrl": {
+                    "description": "",
+                    "name": "iconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/GRR_JCoeurEleves.svg"
+                  },
+                  "locale": {
+                    "description": "",
+                    "name": "locale",
+                    "value": "false"
+                  },
+                  "mobileIconUrl": {
+                    "description": "",
+                    "name": "mobileIconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/GRR_JCoeurEleves.svg"
+                  },
+                  "printable": {
+                    "description": "",
+                    "name": "printable",
+                    "value": "false"
+                  },
+                  "secure": {
+                    "description": "",
+                    "name": "secure",
+                    "value": "false"
+                  },
+                  "showChrome": {
+                    "description": "",
+                    "name": "showChrome",
+                    "value": "true"
+                  }
+                },
+                "ratingsCount": 0,
+                "state": "PUBLISHED",
+                "title": "Gestion et r\u00e9servation de ressources \u00e9l\u00e8ves",
+                "typeId": 6
+              },
+              {
+                "averageRating": 0,
+                "description": "Gestion et r\u00e9servation de ressources                                                                         mat\u00e9riel, \u00e9tablissement, salles, mat\u00e9riel, v\u00e9hicules, \u00e9quipement",
+                "favorite": false,
+                "fname": "GRR2_netocentre",
+                "id": 71,
+                "keywords": [],
+                "name": "GRR netocentre",
+                "parameters": {
+                  "alternate": {
+                    "description": "",
+                    "name": "alternate",
+                    "value": "false"
+                  },
+                  "blockImpersonation": {
+                    "description": "",
+                    "name": "blockImpersonation",
+                    "value": "true"
+                  },
+                  "editable": {
+                    "description": "",
+                    "name": "editable",
+                    "value": "false"
+                  },
+                  "hasAbout": {
+                    "description": "",
+                    "name": "hasAbout",
+                    "value": "false"
+                  },
+                  "hasHelp": {
+                    "description": "",
+                    "name": "hasHelp",
+                    "value": "false"
+                  },
+                  "hideFromDesktop": {
+                    "description": "",
+                    "name": "hideFromDesktop",
+                    "value": "false"
+                  },
+                  "hideFromMobile": {
+                    "description": "",
+                    "name": "hideFromMobile",
+                    "value": "false"
+                  },
+                  "highlight": {
+                    "description": "",
+                    "name": "highlight",
+                    "value": "false"
+                  },
+                  "iconUrl": {
+                    "description": "",
+                    "name": "iconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/GRR2_netocentre.svg"
+                  },
+                  "locale": {
+                    "description": "",
+                    "name": "locale",
+                    "value": "false"
+                  },
+                  "mobileIconUrl": {
+                    "description": "",
+                    "name": "mobileIconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/GRR2_netocentre.svg"
+                  },
+                  "printable": {
+                    "description": "",
+                    "name": "printable",
+                    "value": "false"
+                  },
+                  "secure": {
+                    "description": "",
+                    "name": "secure",
+                    "value": "false"
+                  },
+                  "showChrome": {
+                    "description": "",
+                    "name": "showChrome",
+                    "value": "true"
+                  }
+                },
+                "ratingsCount": 0,
+                "state": "PUBLISHED",
+                "title": "Gestion et r\u00e9servation de ressources",
+                "typeId": 6
+              },
+              {
+                "averageRating": 0,
+                "description": "Gestion Libre de Parc Informatique (GLPI) pour les Lyc\u00e9es et CFA de l'ENT                                    administrateurs, administration, \u00e9tablissement, lyc\u00e9e, coll\u00e8ge\u00a0, CFA, ITS, ordinateurs, PC",
+                "favorite": false,
+                "fname": "GLPI",
+                "id": 69,
+                "keywords": [],
+                "name": "Gestion Libre de Parc Informatique",
+                "parameters": {
+                  "alternate": {
+                    "description": "",
+                    "name": "alternate",
+                    "value": "false"
+                  },
+                  "alternativeMaximizedLink": {
+                    "description": "",
+                    "name": "alternativeMaximizedLink",
+                    "value": "/portail/api/ExternalURLStats?fname=GLPI&service=https://glpi-ent.etab.giprecia.org/"
+                  },
+                  "blockImpersonation": {
+                    "description": "",
+                    "name": "blockImpersonation",
+                    "value": "true"
+                  },
+                  "editable": {
+                    "description": "",
+                    "name": "editable",
+                    "value": "false"
+                  },
+                  "hasAbout": {
+                    "description": "",
+                    "name": "hasAbout",
+                    "value": "false"
+                  },
+                  "hasHelp": {
+                    "description": "",
+                    "name": "hasHelp",
+                    "value": "false"
+                  },
+                  "hideFromDesktop": {
+                    "description": "",
+                    "name": "hideFromDesktop",
+                    "value": "false"
+                  },
+                  "hideFromMobile": {
+                    "description": "",
+                    "name": "hideFromMobile",
+                    "value": "false"
+                  },
+                  "highlight": {
+                    "description": "",
+                    "name": "highlight",
+                    "value": "false"
+                  },
+                  "iconUrl": {
+                    "description": "",
+                    "name": "iconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/GLPI.svg"
+                  },
+                  "locale": {
+                    "description": "",
+                    "name": "locale",
+                    "value": "false"
+                  },
+                  "mobileIconUrl": {
+                    "description": "",
+                    "name": "mobileIconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/GLPI.svg"
+                  },
+                  "printable": {
+                    "description": "",
+                    "name": "printable",
+                    "value": "false"
+                  },
+                  "secure": {
+                    "description": "",
+                    "name": "secure",
+                    "value": "false"
+                  },
+                  "showChrome": {
+                    "description": "",
+                    "name": "showChrome",
+                    "value": "true"
+                  }
+                },
+                "ratingsCount": 0,
+                "state": "PUBLISHED",
+                "title": "Gestion Libre de Parc Informatique",
+                "typeId": 6
+              },
+              {
+                "averageRating": 0,
+                "description": "Statistiques sur les usages de l'ENT                                                                         indicateurs, usages, suivi, \u00e9tablissement",
+                "favorite": false,
+                "fname": "Statistiques",
+                "id": 104,
+                "keywords": [],
+                "name": "Indicateurs d'usage",
+                "parameters": {
+                  "alternate": {
+                    "description": "",
+                    "name": "alternate",
+                    "value": "false"
+                  },
+                  "blockImpersonation": {
+                    "description": "",
+                    "name": "blockImpersonation",
+                    "value": "true"
+                  },
+                  "editable": {
+                    "description": "",
+                    "name": "editable",
+                    "value": "false"
+                  },
+                  "hasAbout": {
+                    "description": "",
+                    "name": "hasAbout",
+                    "value": "false"
+                  },
+                  "hasHelp": {
+                    "description": "",
+                    "name": "hasHelp",
+                    "value": "false"
+                  },
+                  "hideFromDesktop": {
+                    "description": "",
+                    "name": "hideFromDesktop",
+                    "value": "false"
+                  },
+                  "hideFromMobile": {
+                    "description": "",
+                    "name": "hideFromMobile",
+                    "value": "false"
+                  },
+                  "highlight": {
+                    "description": "",
+                    "name": "highlight",
+                    "value": "false"
+                  },
+                  "iconUrl": {
+                    "description": "",
+                    "name": "iconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/Statistiques.svg"
+                  },
+                  "locale": {
+                    "description": "",
+                    "name": "locale",
+                    "value": "false"
+                  },
+                  "mobileIconUrl": {
+                    "description": "",
+                    "name": "mobileIconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/Statistiques.svg"
+                  },
+                  "printable": {
+                    "description": "",
+                    "name": "printable",
+                    "value": "false"
+                  },
+                  "secure": {
+                    "description": "",
+                    "name": "secure",
+                    "value": "false"
+                  },
+                  "showChrome": {
+                    "description": "",
+                    "name": "showChrome",
+                    "value": "true"
+                  }
+                },
+                "ratingsCount": 0,
+                "state": "PUBLISHED",
+                "title": "Indicateurs d'usage",
+                "typeId": 6
+              },
+              {
+                "averageRating": 0,
+                "description": "Les listes de diffusion de l'\u00e9tablissement                                                                     courriel, courrier, \u00e9lectronique, mail, diffuser, poster",
+                "favorite": false,
+                "fname": "ListesDiffusion",
+                "id": 80,
+                "keywords": [],
+                "name": "Listes de diffusion",
+                "parameters": {
+                  "alternate": {
+                    "description": "",
+                    "name": "alternate",
+                    "value": "false"
+                  },
+                  "blockImpersonation": {
+                    "description": "",
+                    "name": "blockImpersonation",
+                    "value": "false"
+                  },
+                  "disableDynamicTitle": {
+                    "description": "",
+                    "name": "disableDynamicTitle",
+                    "value": "true"
+                  },
+                  "editable": {
+                    "description": "",
+                    "name": "editable",
+                    "value": "false"
+                  },
+                  "hasAbout": {
+                    "description": "",
+                    "name": "hasAbout",
+                    "value": "false"
+                  },
+                  "hasHelp": {
+                    "description": "",
+                    "name": "hasHelp",
+                    "value": "false"
+                  },
+                  "hideFromDesktop": {
+                    "description": "",
+                    "name": "hideFromDesktop",
+                    "value": "false"
+                  },
+                  "hideFromMobile": {
+                    "description": "",
+                    "name": "hideFromMobile",
+                    "value": "false"
+                  },
+                  "highlight": {
+                    "description": "",
+                    "name": "highlight",
+                    "value": "false"
+                  },
+                  "iconUrl": {
+                    "description": "",
+                    "name": "iconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/ListesDiffusion.svg"
+                  },
+                  "locale": {
+                    "description": "",
+                    "name": "locale",
+                    "value": "false"
+                  },
+                  "mobileIconUrl": {
+                    "description": "",
+                    "name": "mobileIconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/ListesDiffusion.svg"
+                  },
+                  "printable": {
+                    "description": "",
+                    "name": "printable",
+                    "value": "false"
+                  },
+                  "secure": {
+                    "description": "",
+                    "name": "secure",
+                    "value": "false"
+                  },
+                  "showChrome": {
+                    "description": "",
+                    "name": "showChrome",
+                    "value": "true"
+                  }
+                },
+                "ratingsCount": 0,
+                "state": "PUBLISHED",
+                "title": "Listes de diffusion",
+                "typeId": 7
+              },
+              {
+                "averageRating": 0,
+                "description": "Gestion de mon compte ENT (informations, courriel, mot de passe,...)                                                       mot de passe, adresse \u00e9lectronique, courrier \u00e9lectronique, courriel, mail, classes, groupes, droits",
+                "favorite": false,
+                "fname": "ESCO-MCE",
+                "id": 58,
+                "keywords": [],
+                "name": "Mon compte ENT",
+                "parameters": {
+                  "alternate": {
+                    "description": "",
+                    "name": "alternate",
+                    "value": "false"
+                  },
+                  "blockImpersonation": {
+                    "description": "",
+                    "name": "blockImpersonation",
+                    "value": "true"
+                  },
+                  "editable": {
+                    "description": "",
+                    "name": "editable",
+                    "value": "false"
+                  },
+                  "hasAbout": {
+                    "description": "",
+                    "name": "hasAbout",
+                    "value": "false"
+                  },
+                  "hasHelp": {
+                    "description": "",
+                    "name": "hasHelp",
+                    "value": "false"
+                  },
+                  "hideFromDesktop": {
+                    "description": "",
+                    "name": "hideFromDesktop",
+                    "value": "false"
+                  },
+                  "hideFromMobile": {
+                    "description": "",
+                    "name": "hideFromMobile",
+                    "value": "false"
+                  },
+                  "highlight": {
+                    "description": "",
+                    "name": "highlight",
+                    "value": "false"
+                  },
+                  "iconUrl": {
+                    "description": "",
+                    "name": "iconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/ESCO-MCE.svg"
+                  },
+                  "locale": {
+                    "description": "",
+                    "name": "locale",
+                    "value": "false"
+                  },
+                  "mobileIconUrl": {
+                    "description": "",
+                    "name": "mobileIconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/ESCO-MCE.svg"
+                  },
+                  "printable": {
+                    "description": "",
+                    "name": "printable",
+                    "value": "false"
+                  },
+                  "secure": {
+                    "description": "",
+                    "name": "secure",
+                    "value": "false"
+                  },
+                  "showChrome": {
+                    "description": "",
+                    "name": "showChrome",
+                    "value": "true"
+                  }
+                },
+                "ratingsCount": 0,
+                "state": "PUBLISHED",
+                "title": "Mon compte ENT",
+                "typeId": 6
+              },
+              {
+                "averageRating": 0,
+                "description": "Outil permettant de concevoir des sondages plus ou moins complexes                                           enqu\u00eates, sondages, limesurvey",
+                "favorite": false,
+                "fname": "Limesurvey",
+                "id": 135,
+                "keywords": [],
+                "name": "Outil de sondages",
+                "parameters": {
+                  "alternate": {
+                    "description": "",
+                    "name": "alternate",
+                    "value": "false"
+                  },
+                  "blockImpersonation": {
+                    "description": "",
+                    "name": "blockImpersonation",
+                    "value": "true"
+                  },
+                  "chromeStyle": {
+                    "description": "",
+                    "name": "chromeStyle",
+                    "value": "default"
+                  },
+                  "configurable": {
+                    "description": "",
+                    "name": "configurable",
+                    "value": "false"
+                  },
+                  "disableDynamicTitle": {
+                    "description": "",
+                    "name": "disableDynamicTitle",
+                    "value": "true"
+                  },
+                  "disablePortletEvents": {
+                    "description": "",
+                    "name": "disablePortletEvents",
+                    "value": "false"
+                  },
+                  "editable": {
+                    "description": "",
+                    "name": "editable",
+                    "value": "false"
+                  },
+                  "hasAbout": {
+                    "description": "",
+                    "name": "hasAbout",
+                    "value": "false"
+                  },
+                  "hasHelp": {
+                    "description": "",
+                    "name": "hasHelp",
+                    "value": "false"
+                  },
+                  "hideFromDesktop": {
+                    "description": "",
+                    "name": "hideFromDesktop",
+                    "value": "false"
+                  },
+                  "hideFromMobile": {
+                    "description": "",
+                    "name": "hideFromMobile",
+                    "value": "false"
+                  },
+                  "highlight": {
+                    "description": "",
+                    "name": "highlight",
+                    "value": "false"
+                  },
+                  "iconUrl": {
+                    "description": "",
+                    "name": "iconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/Limesurvey.svg"
+                  },
+                  "locale": {
+                    "description": "",
+                    "name": "locale",
+                    "value": "false"
+                  },
+                  "mobileIconUrl": {
+                    "description": "",
+                    "name": "mobileIconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/Limesurvey.svg"
+                  },
+                  "printable": {
+                    "description": "",
+                    "name": "printable",
+                    "value": "false"
+                  },
+                  "secure": {
+                    "description": "",
+                    "name": "secure",
+                    "value": "false"
+                  },
+                  "showChrome": {
+                    "description": "",
+                    "name": "showChrome",
+                    "value": "true"
+                  }
+                },
+                "ratingsCount": 0,
+                "state": "PUBLISHED",
+                "title": "Outil de sondages",
+                "typeId": 6
+              },
+              {
+                "averageRating": 0,
+                "description": "Plateforme eurecia : gestion Adminsitrative et Ressources humaines                                           RTT, vacances, cong\u00e9s pay\u00e9s, absences, temps de travail, d\u00e9placements, frais, demandes, droits, planning, temps, activit\u00e9s, feuilles de temps",
+                "favorite": false,
+                "fname": "eurecia",
+                "id": 117,
+                "keywords": [],
+                "name": "Outils Administratif RH",
+                "parameters": {
+                  "alternate": {
+                    "description": "",
+                    "name": "alternate",
+                    "value": "false"
+                  },
+                  "alternativeMaximizedLink": {
+                    "description": "",
+                    "name": "alternativeMaximizedLink",
+                    "value": "/portail/api/ExternalURLStats?fname=eurecia&service=https://recia.eurecia.com"
+                  },
+                  "blockImpersonation": {
+                    "description": "",
+                    "name": "blockImpersonation",
+                    "value": "true"
+                  },
+                  "disableDynamicTitle": {
+                    "description": "",
+                    "name": "disableDynamicTitle",
+                    "value": "true"
+                  },
+                  "editable": {
+                    "description": "",
+                    "name": "editable",
+                    "value": "false"
+                  },
+                  "hasAbout": {
+                    "description": "",
+                    "name": "hasAbout",
+                    "value": "false"
+                  },
+                  "hasHelp": {
+                    "description": "",
+                    "name": "hasHelp",
+                    "value": "false"
+                  },
+                  "hideFromDesktop": {
+                    "description": "",
+                    "name": "hideFromDesktop",
+                    "value": "false"
+                  },
+                  "hideFromMobile": {
+                    "description": "",
+                    "name": "hideFromMobile",
+                    "value": "false"
+                  },
+                  "highlight": {
+                    "description": "",
+                    "name": "highlight",
+                    "value": "false"
+                  },
+                  "iconUrl": {
+                    "description": "",
+                    "name": "iconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/eurecia.svg"
+                  },
+                  "mobileIconUrl": {
+                    "description": "",
+                    "name": "mobileIconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/eurecia.svg"
+                  },
+                  "printable": {
+                    "description": "",
+                    "name": "printable",
+                    "value": "false"
+                  },
+                  "showChrome": {
+                    "description": "",
+                    "name": "showChrome",
+                    "value": "true"
+                  }
+                },
+                "ratingsCount": 0,
+                "state": "PUBLISHED",
+                "title": "Outils Administratif RH",
+                "typeId": 4
+              },
+              {
+                "averageRating": 0,
+                "description": "Param\u00e9trage de certains \u00e9l\u00e9ments propres \u00e0 l'\u00e9tablissement pour le portail ENT (nom court, logo)             administration, administrateur, lyc\u00e9e, coll\u00e8ge, CFA, ITS, nom long, personnalisation",
+                "favorite": true,
+                "fname": "ESCO-ParamEtab",
+                "id": 133,
+                "keywords": [],
+                "name": "Param\u00e9trage \u00e9tablissement",
+                "parameters": {
+                  "alternate": {
+                    "description": "",
+                    "name": "alternate",
+                    "value": "false"
+                  },
+                  "blockImpersonation": {
+                    "description": "",
+                    "name": "blockImpersonation",
+                    "value": "true"
+                  },
+                  "chromeStyle": {
+                    "description": "",
+                    "name": "chromeStyle",
+                    "value": "default"
+                  },
+                  "configurable": {
+                    "description": "",
+                    "name": "configurable",
+                    "value": "false"
+                  },
+                  "disableDynamicTitle": {
+                    "description": "",
+                    "name": "disableDynamicTitle",
+                    "value": "true"
+                  },
+                  "disablePortletEvents": {
+                    "description": "",
+                    "name": "disablePortletEvents",
+                    "value": "false"
+                  },
+                  "editable": {
+                    "description": "",
+                    "name": "editable",
+                    "value": "false"
+                  },
+                  "hasAbout": {
+                    "description": "",
+                    "name": "hasAbout",
+                    "value": "false"
+                  },
+                  "hasHelp": {
+                    "description": "",
+                    "name": "hasHelp",
+                    "value": "false"
+                  },
+                  "hideFromDesktop": {
+                    "description": "",
+                    "name": "hideFromDesktop",
+                    "value": "false"
+                  },
+                  "hideFromMobile": {
+                    "description": "",
+                    "name": "hideFromMobile",
+                    "value": "false"
+                  },
+                  "highlight": {
+                    "description": "",
+                    "name": "highlight",
+                    "value": "false"
+                  },
+                  "iconUrl": {
+                    "description": "",
+                    "name": "iconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/ESCO-ParamEtab.svg"
+                  },
+                  "locale": {
+                    "description": "",
+                    "name": "locale",
+                    "value": "false"
+                  },
+                  "mobileIconUrl": {
+                    "description": "",
+                    "name": "mobileIconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/ESCO-ParamEtab.svg"
+                  },
+                  "printable": {
+                    "description": "",
+                    "name": "printable",
+                    "value": "false"
+                  },
+                  "secure": {
+                    "description": "",
+                    "name": "secure",
+                    "value": "false"
+                  },
+                  "showChrome": {
+                    "description": "",
+                    "name": "showChrome",
+                    "value": "true"
+                  }
+                },
+                "ratingsCount": 0,
+                "state": "PUBLISHED",
+                "title": "Param\u00e9trage \u00e9tablissement",
+                "typeId": 6
+              },
+              {
+                "averageRating": 0,
+                "description": "Gestion et publication de contenus (Actualit\u00e9s, Flash information, Ressources, etc...)                       publier, annonces, flash-infos, documents, \u00e9dition, \u00e9diter, mod\u00e9ration, mod\u00e9rer",
+                "favorite": false,
+                "fname": "PublicationContenus",
+                "id": 90,
+                "keywords": [],
+                "name": "Publication de contenus",
+                "parameters": {
+                  "alternate": {
+                    "description": "",
+                    "name": "alternate",
+                    "value": "false"
+                  },
+                  "alternativeMaximizedLink": {
+                    "description": "",
+                    "name": "alternativeMaximizedLink",
+                    "value": ""
+                  },
+                  "blockImpersonation": {
+                    "description": "",
+                    "name": "blockImpersonation",
+                    "value": "false"
+                  },
+                  "editable": {
+                    "description": "",
+                    "name": "editable",
+                    "value": "false"
+                  },
+                  "hasAbout": {
+                    "description": "",
+                    "name": "hasAbout",
+                    "value": "false"
+                  },
+                  "hasHelp": {
+                    "description": "",
+                    "name": "hasHelp",
+                    "value": "false"
+                  },
+                  "hideFromDesktop": {
+                    "description": "",
+                    "name": "hideFromDesktop",
+                    "value": "false"
+                  },
+                  "hideFromMobile": {
+                    "description": "",
+                    "name": "hideFromMobile",
+                    "value": "false"
+                  },
+                  "highlight": {
+                    "description": "",
+                    "name": "highlight",
+                    "value": "false"
+                  },
+                  "iconUrl": {
+                    "description": "",
+                    "name": "iconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/PublicationContenus.svg"
+                  },
+                  "locale": {
+                    "description": "",
+                    "name": "locale",
+                    "value": "false"
+                  },
+                  "mobileIconUrl": {
+                    "description": "",
+                    "name": "mobileIconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/PublicationContenus.svg"
+                  },
+                  "printable": {
+                    "description": "",
+                    "name": "printable",
+                    "value": "false"
+                  },
+                  "secure": {
+                    "description": "",
+                    "name": "secure",
+                    "value": "false"
+                  },
+                  "showChrome": {
+                    "description": "",
+                    "name": "showChrome",
+                    "value": "true"
+                  }
+                },
+                "ratingsCount": 0,
+                "state": "PUBLISHED",
+                "title": "Publication de contenus",
+                "typeId": 6
+              },
+              {
+                "averageRating": 0,
+                "description": "Site web de l'\u00e9tablissement                                                                                    CFA, site institutionnel",
+                "favorite": false,
+                "fname": "SiteEtablissement",
+                "id": 103,
+                "keywords": [],
+                "name": "Site web \u00e9tablissement",
+                "parameters": {
+                  "alternativeMaximizedLink": {
+                    "description": "",
+                    "name": "alternativeMaximizedLink",
+                    "value": "/portail/api/ExternalURLStats?fname=SiteEtablissement&service=/esco-apps-redirector/index.php?appli=SITEETAB"
+                  },
+                  "editable": {
+                    "description": "",
+                    "name": "editable",
+                    "value": "false"
+                  },
+                  "hasAbout": {
+                    "description": "",
+                    "name": "hasAbout",
+                    "value": "false"
+                  },
+                  "hasHelp": {
+                    "description": "",
+                    "name": "hasHelp",
+                    "value": "false"
+                  },
+                  "iconUrl": {
+                    "description": "",
+                    "name": "iconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/SiteEtablissement.svg"
+                  },
+                  "locale": {
+                    "description": "",
+                    "name": "locale",
+                    "value": "false"
+                  },
+                  "mobileIconUrl": {
+                    "description": "",
+                    "name": "mobileIconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/SiteEtablissement.svg"
+                  },
+                  "secure": {
+                    "description": "",
+                    "name": "secure",
+                    "value": "false"
+                  }
+                },
+                "ratingsCount": 0,
+                "state": "PUBLISHED",
+                "title": "Site web de l'\u00e9tablissement",
+                "typeId": 6
+              },
+              {
+                "averageRating": 0,
+                "description": "Application ownCloud du GIP RECIA                                                                              stockage, partage, r\u00e9pertoires, fichiers, multim\u00e9dia, vid\u00e9os, sons, images, documents, versions, nextcloud",
+                "favorite": false,
+                "fname": "OwnCloud_RECIA",
+                "id": 86,
+                "keywords": [],
+                "name": "ownCloud du GIP RECIA",
+                "parameters": {
+                  "alternate": {
+                    "description": "",
+                    "name": "alternate",
+                    "value": "false"
+                  },
+                  "alternativeMaximizedLink": {
+                    "description": "",
+                    "name": "alternativeMaximizedLink",
+                    "value": "/portail/api/ExternalURLStats?fname=Owncloud_RECIA&service=https://owncloud.recia.fr/index.php?app=user_cas"
+                  },
+                  "blockImpersonation": {
+                    "description": "",
+                    "name": "blockImpersonation",
+                    "value": "true"
+                  },
+                  "editable": {
+                    "description": "",
+                    "name": "editable",
+                    "value": "false"
+                  },
+                  "hasAbout": {
+                    "description": "",
+                    "name": "hasAbout",
+                    "value": "false"
+                  },
+                  "hasHelp": {
+                    "description": "",
+                    "name": "hasHelp",
+                    "value": "false"
+                  },
+                  "hideFromDesktop": {
+                    "description": "",
+                    "name": "hideFromDesktop",
+                    "value": "false"
+                  },
+                  "hideFromMobile": {
+                    "description": "",
+                    "name": "hideFromMobile",
+                    "value": "false"
+                  },
+                  "highlight": {
+                    "description": "",
+                    "name": "highlight",
+                    "value": "false"
+                  },
+                  "iconUrl": {
+                    "description": "",
+                    "name": "iconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/OwnCloud_RECIA.svg"
+                  },
+                  "locale": {
+                    "description": "",
+                    "name": "locale",
+                    "value": "false"
+                  },
+                  "mobileIconUrl": {
+                    "description": "",
+                    "name": "mobileIconUrl",
+                    "value": "https://ent.recia.fr/images/portlet_icons/OwnCloud_RECIA.svg"
+                  },
+                  "printable": {
+                    "description": "",
+                    "name": "printable",
+                    "value": "false"
+                  },
+                  "secure": {
+                    "description": "",
+                    "name": "secure",
+                    "value": "false"
+                  }
+                },
+                "ratingsCount": 0,
+                "state": "PUBLISHED",
+                "title": "ownCloud",
+                "typeId": 6
+              }
+            ],
+            "subcategories": []
+          },
+          {
+            "description": "Services natifs uPortal",
+            "id": "local.22",
+            "name": "uPortal",
+            "portlets": [
+              {
+                "averageRating": 0,
+                "description": "Afficher l'activit\u00e9 dans le portail",
+                "favorite": false,
+                "fname": "portal-activity",
+                "id": 22,
+                "keywords": [],
+                "name": "Activit\u00e9 dans le portail",
+                "parameters": {
+                  "iconUrl": {
+                    "description": "",
+                    "name": "iconUrl",
+                    "value": "https://ent.recia.fr/ResourceServingWebapp/rs/tango/0.8.90/32x32/categories/preferences-system.png"
+                  }
+                },
+                "ratingsCount": 0,
+                "state": "PUBLISHED",
+                "title": "Activit\u00e9 dans le portail",
+                "typeId": 7
+              },
+              {
+                "averageRating": 0,
+                "description": "Portlets d'administration des portlets",
+                "favorite": false,
+                "fname": "portlet-admin",
+                "id": 26,
+                "keywords": [],
+                "name": "Administration des portlets",
+                "parameters": {
+                  "iconUrl": {
+                    "description": "",
+                    "name": "iconUrl",
+                    "value": "https://ent.recia.fr/ResourceServingWebapp/rs/tango/0.8.90/32x32/categories/preferences-system.png"
+                  }
+                },
+                "ratingsCount": 0,
+                "state": "PUBLISHED",
+                "title": "Administration des portlets",
+                "typeId": 7
+              },
+              {
+                "averageRating": 0,
+                "description": "Menu des portlets d'administration du portail",
+                "favorite": true,
+                "fname": "portal-administration",
+                "id": 23,
+                "keywords": [],
+                "name": "Administration du portail",
+                "parameters": {
+                  "iconUrl": {
+                    "description": "",
+                    "name": "iconUrl",
+                    "value": "https://ent.recia.fr/ResourceServingWebapp/rs/tango/0.8.90/32x32/categories/preferences-system.png"
+                  }
+                },
+                "ratingsCount": 0,
+                "state": "PUBLISHED",
+                "title": "Administration du portail",
+                "typeId": 7
+              },
+              {
+                "averageRating": 0,
+                "description": "Liste les portlets qui ont \u00e9t\u00e9 ajout\u00e9es par les utilisateurs",
+                "favorite": false,
+                "fname": "popular-portlets",
+                "id": 21,
+                "keywords": [],
+                "name": "Applications les plus populaires",
+                "parameters": {
+                  "iconUrl": {
+                    "description": "",
+                    "name": "iconUrl",
+                    "value": "https://ent.recia.fr/ResourceServingWebapp/rs/tango/0.8.90/32x32/categories/preferences-system.png"
+                  }
+                },
+                "ratingsCount": 0,
+                "state": "PUBLISHED",
+                "title": "Applications les plus populaires",
+                "typeId": 7
+              },
+              {
+                "averageRating": 0,
+                "description": "Gestion des groupes du portail",
+                "favorite": false,
+                "fname": "groupsmanager",
+                "id": 12,
+                "keywords": [],
+                "name": "Gestion des groupes",
+                "parameters": {
+                  "iconUrl": {
+                    "description": "",
+                    "name": "iconUrl",
+                    "value": "https://ent.recia.fr/ResourceServingWebapp/rs/tango/0.8.90/32x32/apps/system-users.png"
+                  }
+                },
+                "ratingsCount": 0,
+                "state": "PUBLISHED",
+                "title": "Gestion des groupes",
+                "typeId": 7
+              },
+              {
+                "averageRating": 0,
+                "description": "Gestion des mots de passe",
+                "favorite": false,
+                "fname": "passwordmgr",
+                "id": 18,
+                "keywords": [],
+                "name": "Gestion des mots de passe",
+                "parameters": {
+                  "iconUrl": {
+                    "description": "",
+                    "name": "iconUrl",
+                    "value": "https://ent.recia.fr/ResourceServingWebapp/rs/tango/0.8.90/32x32/categories/preferences-system.png"
+                  }
+                },
+                "ratingsCount": 0,
+                "state": "PUBLISHED",
+                "title": "Gestion des mots de passe",
+                "typeId": 7
+              },
+              {
+                "averageRating": 0,
+                "description": "Portlet de gestion des permissions",
+                "favorite": false,
+                "fname": "permissionsmanager",
+                "id": 19,
+                "keywords": [],
+                "name": "Gestion des permissions",
+                "parameters": {
+                  "iconUrl": {
+                    "description": "",
+                    "name": "iconUrl",
+                    "value": "https://ent.recia.fr/ResourceServingWebapp/rs/tango/0.8.90/32x32/categories/preferences-system.png"
+                  }
+                },
+                "ratingsCount": 0,
+                "state": "PUBLISHED",
+                "title": "Gestion des permissions",
+                "typeId": 7
+              },
+              {
+                "averageRating": 0,
+                "description": "Menu des outils de gestion des utilisateurs",
+                "favorite": false,
+                "fname": "user-administration",
+                "id": 38,
+                "keywords": [],
+                "name": "Gestion des utilisateurs",
+                "parameters": {
+                  "iconUrl": {
+                    "description": "",
+                    "name": "iconUrl",
+                    "value": "https://ent.recia.fr/ResourceServingWebapp/rs/tango/0.8.90/32x32/apps/system-users.png"
+                  }
+                },
+                "ratingsCount": 0,
+                "state": "PUBLISHED",
+                "title": "Gestion des utilisateurs",
+                "typeId": 7
+              },
+              {
+                "averageRating": 0,
+                "description": "Visualiser les statistiques du portail.",
+                "favorite": false,
+                "fname": "statistics",
+                "id": 33,
+                "keywords": [],
+                "name": "Statistiques",
+                "parameters": {
+                  "disableDynamicTitle": {
+                    "description": "",
+                    "name": "disableDynamicTitle",
+                    "value": "true"
+                  },
+                  "iconUrl": {
+                    "description": "",
+                    "name": "iconUrl",
+                    "value": "https://ent.recia.fr/ResourceServingWebapp/rs/tango/0.8.90/32x32/mimetypes/x-office-spreadsheet.png"
+                  }
+                },
+                "ratingsCount": 0,
+                "state": "PUBLISHED",
+                "title": "Statistiques",
+                "typeId": 7
+              }
+            ],
+            "subcategories": []
+          }
+        ]
+      },
+      {
+        "description": "Portlets non class\u00e9es dans les cat\u00e9gories",
+        "id": "Non class\u00e9e",
+        "name": "Non class\u00e9e",
+        "portlets": [
+          {
+            "averageRating": 0,
+            "description": "Accueil Bad, indique un probl\u00e8me",
+            "favorite": false,
+            "fname": "Accueil_Bad",
+            "id": 41,
+            "keywords": [],
+            "name": "Accueil Bad",
+            "parameters": {
+              "editable": {
+                "description": "",
+                "name": "editable",
+                "value": "false"
+              },
+              "hasAbout": {
+                "description": "",
+                "name": "hasAbout",
+                "value": "false"
+              },
+              "hasHelp": {
+                "description": "",
+                "name": "hasHelp",
+                "value": "false"
+              },
+              "locale": {
+                "description": "",
+                "name": "locale",
+                "value": "false"
+              },
+              "printable": {
+                "description": "",
+                "name": "printable",
+                "value": "false"
+              },
+              "secure": {
+                "description": "",
+                "name": "secure",
+                "value": "false"
+              },
+              "showChrome": {
+                "description": "",
+                "name": "showChrome",
+                "value": "false"
+              }
+            },
+            "ratingsCount": 0,
+            "state": "PUBLISHED",
+            "title": "Accueil",
+            "typeId": 4
+          },
+          {
+            "averageRating": 0,
+            "description": "Aide \u00e0 la prise en main du nouveau portail",
+            "favorite": false,
+            "fname": "HelpInfo",
+            "id": 73,
+            "keywords": [],
+            "name": "Aide du nouveau portail",
+            "parameters": {
+              "alternate": {
+                "description": "",
+                "name": "alternate",
+                "value": "false"
+              },
+              "blockImpersonation": {
+                "description": "",
+                "name": "blockImpersonation",
+                "value": "false"
+              },
+              "disableDynamicTitle": {
+                "description": "",
+                "name": "disableDynamicTitle",
+                "value": "true"
+              },
+              "editable": {
+                "description": "",
+                "name": "editable",
+                "value": "false"
+              },
+              "hasAbout": {
+                "description": "",
+                "name": "hasAbout",
+                "value": "false"
+              },
+              "hasHelp": {
+                "description": "",
+                "name": "hasHelp",
+                "value": "false"
+              },
+              "hideFromDesktop": {
+                "description": "",
+                "name": "hideFromDesktop",
+                "value": "false"
+              },
+              "hideFromMobile": {
+                "description": "",
+                "name": "hideFromMobile",
+                "value": "false"
+              },
+              "highlight": {
+                "description": "",
+                "name": "highlight",
+                "value": "false"
+              },
+              "iconUrl": {
+                "description": "",
+                "name": "iconUrl",
+                "value": "https://ent.recia.fr/images/portlet_icons/HelpInfo.svg"
+              },
+              "locale": {
+                "description": "",
+                "name": "locale",
+                "value": "false"
+              },
+              "mobileIconUrl": {
+                "description": "",
+                "name": "mobileIconUrl",
+                "value": "https://ent.recia.fr/images/portlet_icons/HelpInfo.svg"
+              },
+              "printable": {
+                "description": "",
+                "name": "printable",
+                "value": "false"
+              },
+              "secure": {
+                "description": "",
+                "name": "secure",
+                "value": "false"
+              },
+              "showChrome": {
+                "description": "",
+                "name": "showChrome",
+                "value": "false"
+              }
+            },
+            "ratingsCount": 0,
+            "state": "PUBLISHED",
+            "title": "Aide du nouveau portail",
+            "typeId": 7
+          },
+          {
+            "averageRating": 0,
+            "description": "Manage portal attachments",
+            "favorite": false,
+            "fname": "attachments",
+            "id": 3,
+            "keywords": [],
+            "name": "Attachments",
+            "parameters": {
+              "alternate": {
+                "description": "",
+                "name": "alternate",
+                "value": "false"
+              },
+              "blockImpersonation": {
+                "description": "",
+                "name": "blockImpersonation",
+                "value": "false"
+              },
+              "disableDynamicTitle": {
+                "description": "",
+                "name": "disableDynamicTitle",
+                "value": "true"
+              },
+              "editable": {
+                "description": "",
+                "name": "editable",
+                "value": "false"
+              },
+              "hasAbout": {
+                "description": "",
+                "name": "hasAbout",
+                "value": "false"
+              },
+              "hasHelp": {
+                "description": "",
+                "name": "hasHelp",
+                "value": "false"
+              },
+              "hideFromMobile": {
+                "description": "",
+                "name": "hideFromMobile",
+                "value": "true"
+              },
+              "highlight": {
+                "description": "",
+                "name": "highlight",
+                "value": "false"
+              },
+              "role": {
+                "description": "",
+                "name": "role",
+                "value": "tips"
+              },
+              "showChrome": {
+                "description": "",
+                "name": "showChrome",
+                "value": "false"
+              }
+            },
+            "ratingsCount": 0,
+            "state": "PUBLISHED",
+            "title": "Attachments",
+            "typeId": 7
+          },
+          {
+            "averageRating": 0,
+            "description": "D\u00e9tection du navigateur",
+            "favorite": false,
+            "fname": "browser-detect",
+            "id": 128,
+            "keywords": [],
+            "name": "Browser Detection",
+            "parameters": {
+              "disableDynamicTitle": {
+                "description": "",
+                "name": "disableDynamicTitle",
+                "value": "true"
+              }
+            },
+            "ratingsCount": 0,
+            "state": "PUBLISHED",
+            "title": "Browser Detection",
+            "typeId": 7
+          },
+          {
+            "averageRating": 0,
+            "description": "Formulaire de connexion locale au portail",
+            "favorite": false,
+            "fname": "login",
+            "id": 16,
+            "keywords": [],
+            "name": "Connexion",
+            "parameters": {},
+            "ratingsCount": 0,
+            "state": "PUBLISHED",
+            "title": "Connexion",
+            "typeId": 7
+          },
+          {
+            "averageRating": 0,
+            "description": "Compiles Bootstrap LESS dynamically, allowing administrators to make some skin configuration choices in a UI.  Supports the optional 'dynamic' strategy for Respondr.",
+            "favorite": false,
+            "fname": "dynamic-respondr-skin-ef2s",
+            "id": 143,
+            "keywords": [],
+            "name": "Dynamic Respondr Skin EF2S",
+            "parameters": {
+              "configurable": {
+                "description": "",
+                "name": "configurable",
+                "value": "true"
+              },
+              "disableDynamicTitle": {
+                "description": "",
+                "name": "disableDynamicTitle",
+                "value": "true"
+              },
+              "iconUrl": {
+                "description": "",
+                "name": "iconUrl",
+                "value": "https://ent.recia.fr/ResourceServingWebapp/rs/tango/0.8.90/32x32/apps/preferences-desktop-theme.png"
+              },
+              "mobileIconUrl": {
+                "description": "",
+                "name": "mobileIconUrl",
+                "value": "https://ent.recia.fr/ResourceServingWebapp/rs/tango/0.8.90/32x32/apps/preferences-desktop-theme.png"
+              }
+            },
+            "ratingsCount": 0,
+            "state": "PUBLISHED",
+            "title": "Dynamic Respondr Skin EF2S",
+            "typeId": 7
+          },
+          {
+            "averageRating": 0,
+            "description": "Compiles Bootstrap LESS dynamically, allowing administrators to make some skin configuration choices in a UI.  Supports the optional 'dynamic' strategy for Respondr.",
+            "favorite": false,
+            "fname": "dynamic-respondr-skin-recia",
+            "id": 144,
+            "keywords": [],
+            "name": "Dynamic Respondr Skin RECIA",
+            "parameters": {
+              "configurable": {
+                "description": "",
+                "name": "configurable",
+                "value": "true"
+              },
+              "disableDynamicTitle": {
+                "description": "",
+                "name": "disableDynamicTitle",
+                "value": "true"
+              },
+              "iconUrl": {
+                "description": "",
+                "name": "iconUrl",
+                "value": "https://ent.recia.fr/ResourceServingWebapp/rs/tango/0.8.90/32x32/apps/preferences-desktop-theme.png"
+              },
+              "mobileIconUrl": {
+                "description": "",
+                "name": "mobileIconUrl",
+                "value": "https://ent.recia.fr/ResourceServingWebapp/rs/tango/0.8.90/32x32/apps/preferences-desktop-theme.png"
+              }
+            },
+            "ratingsCount": 0,
+            "state": "PUBLISHED",
+            "title": "Dynamic Respondr Skin RECIA",
+            "typeId": 7
+          },
+          {
+            "averageRating": 0,
+            "description": "Compiles Bootstrap LESS dynamically, allowing administrators to make some skin configuration choices in a UI.  Supports the optional 'dynamic' strategy for Respondr.",
+            "favorite": false,
+            "fname": "dynamic-respondr-skin-webocentre",
+            "id": 145,
+            "keywords": [],
+            "name": "Dynamic Respondr Skin WEBOCENTRE",
+            "parameters": {
+              "configurable": {
+                "description": "",
+                "name": "configurable",
+                "value": "true"
+              },
+              "disableDynamicTitle": {
+                "description": "",
+                "name": "disableDynamicTitle",
+                "value": "true"
+              },
+              "iconUrl": {
+                "description": "",
+                "name": "iconUrl",
+                "value": "https://ent.recia.fr/ResourceServingWebapp/rs/tango/0.8.90/32x32/apps/preferences-desktop-theme.png"
+              },
+              "mobileIconUrl": {
+                "description": "",
+                "name": "mobileIconUrl",
+                "value": "https://ent.recia.fr/ResourceServingWebapp/rs/tango/0.8.90/32x32/apps/preferences-desktop-theme.png"
+              }
+            },
+            "ratingsCount": 0,
+            "state": "PUBLISHED",
+            "title": "Dynamic Respondr Skin WEBOCENTRE",
+            "typeId": 7
+          },
+          {
+            "averageRating": 0,
+            "description": "Affiche un message d'erreur quand la portlet initiale ne peut pas s'afficher.",
+            "favorite": false,
+            "fname": "error",
+            "id": 6,
+            "keywords": [],
+            "name": "Erreur",
+            "parameters": {
+              "iconUrl": {
+                "description": "",
+                "name": "iconUrl",
+                "value": "https://ent.recia.fr/ResourceServingWebapp/rs/tango/0.8.90/32x32/status/dialog-warning.png"
+              }
+            },
+            "ratingsCount": 0,
+            "state": "PUBLISHED",
+            "title": "Erreur",
+            "typeId": 7
+          },
+          {
+            "averageRating": 0,
+            "description": "Les \"Flash Info\" CFA en mode non connect\u00e9",
+            "favorite": false,
+            "fname": "FlashInfoGuestCFA",
+            "id": 62,
+            "keywords": [],
+            "name": "Flash Info Guest CFA",
+            "parameters": {
+              "alternate": {
+                "description": "",
+                "name": "alternate",
+                "value": "false"
+              },
+              "blockImpersonation": {
+                "description": "",
+                "name": "blockImpersonation",
+                "value": "false"
+              },
+              "disableDynamicTitle": {
+                "description": "",
+                "name": "disableDynamicTitle",
+                "value": "true"
+              },
+              "editable": {
+                "description": "",
+                "name": "editable",
+                "value": "false"
+              },
+              "hasAbout": {
+                "description": "",
+                "name": "hasAbout",
+                "value": "false"
+              },
+              "hasHelp": {
+                "description": "",
+                "name": "hasHelp",
+                "value": "false"
+              },
+              "hideFromDesktop": {
+                "description": "",
+                "name": "hideFromDesktop",
+                "value": "false"
+              },
+              "hideFromMobile": {
+                "description": "",
+                "name": "hideFromMobile",
+                "value": "false"
+              },
+              "highlight": {
+                "description": "",
+                "name": "highlight",
+                "value": "false"
+              },
+              "iconUrl": {
+                "description": "",
+                "name": "iconUrl",
+                "value": "https://ent.recia.fr/images/portlet_icons/Annonces.png"
+              },
+              "locale": {
+                "description": "",
+                "name": "locale",
+                "value": "false"
+              },
+              "mobileIconUrl": {
+                "description": "",
+                "name": "mobileIconUrl",
+                "value": "https://ent.recia.fr/images/portlet_icons/Annonces.png"
+              },
+              "printable": {
+                "description": "",
+                "name": "printable",
+                "value": "false"
+              },
+              "secure": {
+                "description": "",
+                "name": "secure",
+                "value": "false"
+              },
+              "showChrome": {
+                "description": "",
+                "name": "showChrome",
+                "value": "true"
+              }
+            },
+            "ratingsCount": 0,
+            "state": "PUBLISHED",
+            "title": "Flash Info Guest CFA",
+            "typeId": 7
+          },
+          {
+            "averageRating": 0,
+            "description": "Les \"Flash Info\" des coll\u00e8ges de l'Indre-et-Loire en mode non connect\u00e9",
+            "favorite": false,
+            "fname": "FlashInfoGuestCLG37",
+            "id": 63,
+            "keywords": [],
+            "name": "Flash Info Guest CLG37",
+            "parameters": {
+              "alternate": {
+                "description": "",
+                "name": "alternate",
+                "value": "false"
+              },
+              "blockImpersonation": {
+                "description": "",
+                "name": "blockImpersonation",
+                "value": "false"
+              },
+              "disableDynamicTitle": {
+                "description": "",
+                "name": "disableDynamicTitle",
+                "value": "true"
+              },
+              "editable": {
+                "description": "",
+                "name": "editable",
+                "value": "false"
+              },
+              "hasAbout": {
+                "description": "",
+                "name": "hasAbout",
+                "value": "false"
+              },
+              "hasHelp": {
+                "description": "",
+                "name": "hasHelp",
+                "value": "false"
+              },
+              "hideFromDesktop": {
+                "description": "",
+                "name": "hideFromDesktop",
+                "value": "false"
+              },
+              "hideFromMobile": {
+                "description": "",
+                "name": "hideFromMobile",
+                "value": "false"
+              },
+              "highlight": {
+                "description": "",
+                "name": "highlight",
+                "value": "false"
+              },
+              "iconUrl": {
+                "description": "",
+                "name": "iconUrl",
+                "value": "https://ent.recia.fr/images/portlet_icons/Annonces.png"
+              },
+              "locale": {
+                "description": "",
+                "name": "locale",
+                "value": "false"
+              },
+              "mobileIconUrl": {
+                "description": "",
+                "name": "mobileIconUrl",
+                "value": "https://ent.recia.fr/images/portlet_icons/Annonces.png"
+              },
+              "printable": {
+                "description": "",
+                "name": "printable",
+                "value": "false"
+              },
+              "secure": {
+                "description": "",
+                "name": "secure",
+                "value": "false"
+              },
+              "showChrome": {
+                "description": "",
+                "name": "showChrome",
+                "value": "true"
+              }
+            },
+            "ratingsCount": 0,
+            "state": "PUBLISHED",
+            "title": "Flash Info Guest CLG37",
+            "typeId": 7
+          },
+          {
+            "averageRating": 0,
+            "description": "Les \"Flash Info\" EF2S en mode non connect\u00e9",
+            "favorite": false,
+            "fname": "FlashInfoGuestEF2S",
+            "id": 64,
+            "keywords": [],
+            "name": "Flash Info Guest EF2S",
+            "parameters": {
+              "alternate": {
+                "description": "",
+                "name": "alternate",
+                "value": "false"
+              },
+              "blockImpersonation": {
+                "description": "",
+                "name": "blockImpersonation",
+                "value": "false"
+              },
+              "disableDynamicTitle": {
+                "description": "",
+                "name": "disableDynamicTitle",
+                "value": "true"
+              },
+              "editable": {
+                "description": "",
+                "name": "editable",
+                "value": "false"
+              },
+              "hasAbout": {
+                "description": "",
+                "name": "hasAbout",
+                "value": "false"
+              },
+              "hasHelp": {
+                "description": "",
+                "name": "hasHelp",
+                "value": "false"
+              },
+              "hideFromDesktop": {
+                "description": "",
+                "name": "hideFromDesktop",
+                "value": "false"
+              },
+              "hideFromMobile": {
+                "description": "",
+                "name": "hideFromMobile",
+                "value": "false"
+              },
+              "highlight": {
+                "description": "",
+                "name": "highlight",
+                "value": "false"
+              },
+              "iconUrl": {
+                "description": "",
+                "name": "iconUrl",
+                "value": "https://ent.recia.fr/images/portlet_icons/Annonces.png"
+              },
+              "locale": {
+                "description": "",
+                "name": "locale",
+                "value": "false"
+              },
+              "mobileIconUrl": {
+                "description": "",
+                "name": "mobileIconUrl",
+                "value": "https://ent.recia.fr/images/portlet_icons/Annonces.png"
+              },
+              "printable": {
+                "description": "",
+                "name": "printable",
+                "value": "false"
+              },
+              "secure": {
+                "description": "",
+                "name": "secure",
+                "value": "false"
+              },
+              "showChrome": {
+                "description": "",
+                "name": "showChrome",
+                "value": "true"
+              }
+            },
+            "ratingsCount": 0,
+            "state": "PUBLISHED",
+            "title": "Flash Info Guest EF2S",
+            "typeId": 7
+          },
+          {
+            "averageRating": 0,
+            "description": "Les \"Flash Info\" lyc\u00e9es en mode non connect\u00e9",
+            "favorite": false,
+            "fname": "FlashInfoGuestLycees",
+            "id": 65,
+            "keywords": [],
+            "name": "Flash Info Guest Lycees",
+            "parameters": {
+              "alternate": {
+                "description": "",
+                "name": "alternate",
+                "value": "false"
+              },
+              "blockImpersonation": {
+                "description": "",
+                "name": "blockImpersonation",
+                "value": "false"
+              },
+              "disableDynamicTitle": {
+                "description": "",
+                "name": "disableDynamicTitle",
+                "value": "true"
+              },
+              "editable": {
+                "description": "",
+                "name": "editable",
+                "value": "false"
+              },
+              "hasAbout": {
+                "description": "",
+                "name": "hasAbout",
+                "value": "false"
+              },
+              "hasHelp": {
+                "description": "",
+                "name": "hasHelp",
+                "value": "false"
+              },
+              "hideFromDesktop": {
+                "description": "",
+                "name": "hideFromDesktop",
+                "value": "false"
+              },
+              "hideFromMobile": {
+                "description": "",
+                "name": "hideFromMobile",
+                "value": "false"
+              },
+              "highlight": {
+                "description": "",
+                "name": "highlight",
+                "value": "false"
+              },
+              "iconUrl": {
+                "description": "",
+                "name": "iconUrl",
+                "value": "https://ent.recia.fr/images/portlet_icons/Annonces.png"
+              },
+              "locale": {
+                "description": "",
+                "name": "locale",
+                "value": "false"
+              },
+              "mobileIconUrl": {
+                "description": "",
+                "name": "mobileIconUrl",
+                "value": "https://ent.recia.fr/images/portlet_icons/Annonces.png"
+              },
+              "printable": {
+                "description": "",
+                "name": "printable",
+                "value": "false"
+              },
+              "secure": {
+                "description": "",
+                "name": "secure",
+                "value": "false"
+              },
+              "showChrome": {
+                "description": "",
+                "name": "showChrome",
+                "value": "true"
+              }
+            },
+            "ratingsCount": 0,
+            "state": "PUBLISHED",
+            "title": "Flash Info Guest Lycees",
+            "typeId": 7
+          },
+          {
+            "averageRating": 0,
+            "description": "Les \"Flash Info\" Recia en mode non connect\u00e9",
+            "favorite": false,
+            "fname": "FlashInfoGuestRecia",
+            "id": 66,
+            "keywords": [],
+            "name": "Flash Info Guest Recia",
+            "parameters": {
+              "alternate": {
+                "description": "",
+                "name": "alternate",
+                "value": "false"
+              },
+              "blockImpersonation": {
+                "description": "",
+                "name": "blockImpersonation",
+                "value": "false"
+              },
+              "disableDynamicTitle": {
+                "description": "",
+                "name": "disableDynamicTitle",
+                "value": "true"
+              },
+              "editable": {
+                "description": "",
+                "name": "editable",
+                "value": "false"
+              },
+              "hasAbout": {
+                "description": "",
+                "name": "hasAbout",
+                "value": "false"
+              },
+              "hasHelp": {
+                "description": "",
+                "name": "hasHelp",
+                "value": "false"
+              },
+              "hideFromDesktop": {
+                "description": "",
+                "name": "hideFromDesktop",
+                "value": "false"
+              },
+              "hideFromMobile": {
+                "description": "",
+                "name": "hideFromMobile",
+                "value": "false"
+              },
+              "highlight": {
+                "description": "",
+                "name": "highlight",
+                "value": "false"
+              },
+              "iconUrl": {
+                "description": "",
+                "name": "iconUrl",
+                "value": "https://ent.recia.fr/images/portlet_icons/Annonces.png"
+              },
+              "locale": {
+                "description": "",
+                "name": "locale",
+                "value": "false"
+              },
+              "mobileIconUrl": {
+                "description": "",
+                "name": "mobileIconUrl",
+                "value": "https://ent.recia.fr/images/portlet_icons/Annonces.png"
+              },
+              "printable": {
+                "description": "",
+                "name": "printable",
+                "value": "false"
+              },
+              "secure": {
+                "description": "",
+                "name": "secure",
+                "value": "false"
+              },
+              "showChrome": {
+                "description": "",
+                "name": "showChrome",
+                "value": "true"
+              }
+            },
+            "ratingsCount": 0,
+            "state": "PUBLISHED",
+            "title": "Flash Info Guest Recia",
+            "typeId": 7
+          },
+          {
+            "averageRating": 0,
+            "description": "Les \"Flash Info\" Webocentre en mode non connect\u00e9",
+            "favorite": false,
+            "fname": "FlashInfoGuestWebocentre",
+            "id": 67,
+            "keywords": [],
+            "name": "Flash Info Guest Webocentre",
+            "parameters": {
+              "alternate": {
+                "description": "",
+                "name": "alternate",
+                "value": "false"
+              },
+              "blockImpersonation": {
+                "description": "",
+                "name": "blockImpersonation",
+                "value": "false"
+              },
+              "disableDynamicTitle": {
+                "description": "",
+                "name": "disableDynamicTitle",
+                "value": "true"
+              },
+              "editable": {
+                "description": "",
+                "name": "editable",
+                "value": "false"
+              },
+              "hasAbout": {
+                "description": "",
+                "name": "hasAbout",
+                "value": "false"
+              },
+              "hasHelp": {
+                "description": "",
+                "name": "hasHelp",
+                "value": "false"
+              },
+              "hideFromDesktop": {
+                "description": "",
+                "name": "hideFromDesktop",
+                "value": "false"
+              },
+              "hideFromMobile": {
+                "description": "",
+                "name": "hideFromMobile",
+                "value": "false"
+              },
+              "highlight": {
+                "description": "",
+                "name": "highlight",
+                "value": "false"
+              },
+              "iconUrl": {
+                "description": "",
+                "name": "iconUrl",
+                "value": "https://ent.recia.fr/images/portlet_icons/Annonces.png"
+              },
+              "locale": {
+                "description": "",
+                "name": "locale",
+                "value": "false"
+              },
+              "mobileIconUrl": {
+                "description": "",
+                "name": "mobileIconUrl",
+                "value": "https://ent.recia.fr/images/portlet_icons/Annonces.png"
+              },
+              "printable": {
+                "description": "",
+                "name": "printable",
+                "value": "false"
+              },
+              "secure": {
+                "description": "",
+                "name": "secure",
+                "value": "false"
+              },
+              "showChrome": {
+                "description": "",
+                "name": "showChrome",
+                "value": "true"
+              }
+            },
+            "ratingsCount": 0,
+            "state": "PUBLISHED",
+            "title": "Flash Info Guest Webocentre",
+            "typeId": 7
+          },
+          {
+            "averageRating": 0,
+            "description": "Les \"Flash Info\" de l'\u00e9tablissement courant                                                                    informations, flash-information, lyc\u00e9e, coll\u00e8ge, CFA, ITS, br\u00e8ves, annonces, nouvelles, actualit\u00e9s",
+            "favorite": false,
+            "fname": "FlashInfoEtab",
+            "id": 61,
+            "keywords": [],
+            "name": "Flash Info de l'\u00e9tablissement",
+            "parameters": {
+              "alternate": {
+                "description": "",
+                "name": "alternate",
+                "value": "false"
+              },
+              "blockImpersonation": {
+                "description": "",
+                "name": "blockImpersonation",
+                "value": "false"
+              },
+              "disableDynamicTitle": {
+                "description": "",
+                "name": "disableDynamicTitle",
+                "value": "true"
+              },
+              "editable": {
+                "description": "",
+                "name": "editable",
+                "value": "false"
+              },
+              "hasAbout": {
+                "description": "",
+                "name": "hasAbout",
+                "value": "false"
+              },
+              "hasHelp": {
+                "description": "",
+                "name": "hasHelp",
+                "value": "false"
+              },
+              "hideFromDesktop": {
+                "description": "",
+                "name": "hideFromDesktop",
+                "value": "false"
+              },
+              "hideFromMobile": {
+                "description": "",
+                "name": "hideFromMobile",
+                "value": "false"
+              },
+              "highlight": {
+                "description": "",
+                "name": "highlight",
+                "value": "false"
+              },
+              "iconUrl": {
+                "description": "",
+                "name": "iconUrl",
+                "value": "https://ent.recia.fr/images/portlet_icons/FlashInfoEtab.svg"
+              },
+              "locale": {
+                "description": "",
+                "name": "locale",
+                "value": "false"
+              },
+              "mobileIconUrl": {
+                "description": "",
+                "name": "mobileIconUrl",
+                "value": "https://ent.recia.fr/images/portlet_icons/FlashInfoEtab.svg"
+              },
+              "printable": {
+                "description": "",
+                "name": "printable",
+                "value": "false"
+              },
+              "secure": {
+                "description": "",
+                "name": "secure",
+                "value": "false"
+              },
+              "showChrome": {
+                "description": "",
+                "name": "showChrome",
+                "value": "true"
+              }
+            },
+            "ratingsCount": 0,
+            "state": "PUBLISHED",
+            "title": "Flash Info de l'\u00e9tablissement",
+            "typeId": 7
+          },
+          {
+            "averageRating": 0,
+            "description": "Script for the auto-fit of iframes",
+            "favorite": false,
+            "fname": "iframe-resizer",
+            "id": 130,
+            "keywords": [],
+            "name": "Iframe Resizer",
+            "parameters": {
+              "configurable": {
+                "description": "",
+                "name": "configurable",
+                "value": "true"
+              },
+              "disableDynamicTitle": {
+                "description": "",
+                "name": "disableDynamicTitle",
+                "value": "false"
+              }
+            },
+            "ratingsCount": 0,
+            "state": "PUBLISHED",
+            "title": "Iframe Resizer",
+            "typeId": 7
+          },
+          {
+            "averageRating": 0,
+            "description": "Afficher les informations utilisateur dans l'ent\u00eate",
+            "favorite": false,
+            "fname": "eyebrow-user-info",
+            "id": 122,
+            "keywords": [],
+            "name": "Informations utilisateur eyebrow Header",
+            "parameters": {
+              "disableDynamicTitle": {
+                "description": "",
+                "name": "disableDynamicTitle",
+                "value": "true"
+              }
+            },
+            "ratingsCount": 0,
+            "state": "PUBLISHED",
+            "title": "Informations utilisateur Header",
+            "typeId": 7
+          },
+          {
+            "averageRating": 0,
+            "description": "Legal links for uPortal",
+            "favorite": false,
+            "fname": "legal-footer",
+            "id": 14,
+            "keywords": [],
+            "name": "Legal Footer",
+            "parameters": {
+              "configurable": {
+                "description": "",
+                "name": "configurable",
+                "value": "true"
+              },
+              "disableDynamicTitle": {
+                "description": "",
+                "name": "disableDynamicTitle",
+                "value": "true"
+              }
+            },
+            "ratingsCount": 0,
+            "state": "PUBLISHED",
+            "title": "Legal Footer",
+            "typeId": 7
+          },
+          {
+            "averageRating": 0,
+            "description": "Login Launcher form for local portal authentication",
+            "favorite": false,
+            "fname": "login-launcher",
+            "id": 15,
+            "keywords": [],
+            "name": "Login Launcher",
+            "parameters": {
+              "disableDynamicTitle": {
+                "description": "",
+                "name": "disableDynamicTitle",
+                "value": "true"
+              }
+            },
+            "ratingsCount": 0,
+            "state": "PUBLISHED",
+            "title": "Login Launcher",
+            "typeId": 7
+          },
+          {
+            "averageRating": 0,
+            "description": "Provides a link to log out of the portal for authenticated users",
+            "favorite": false,
+            "fname": "logout-launcher",
+            "id": 17,
+            "keywords": [],
+            "name": "Logout Launcher",
+            "parameters": {
+              "disableDynamicTitle": {
+                "description": "",
+                "name": "disableDynamicTitle",
+                "value": "true"
+              }
+            },
+            "ratingsCount": 0,
+            "state": "PUBLISHED",
+            "title": "Logout Launcher",
+            "typeId": 7
+          },
+          {
+            "averageRating": 0,
+            "description": "Marqueur Xiti",
+            "favorite": false,
+            "fname": "xiti",
+            "id": 127,
+            "keywords": [],
+            "name": "Marqueur Xiti",
+            "parameters": {
+              "disableDynamicTitle": {
+                "description": "",
+                "name": "disableDynamicTitle",
+                "value": "true"
+              }
+            },
+            "ratingsCount": 0,
+            "state": "PUBLISHED",
+            "title": "Marqueur Xiti",
+            "typeId": 7
+          },
+          {
+            "averageRating": 0,
+            "description": "Nouveau type de menu",
+            "favorite": false,
+            "fname": "content-menu",
+            "id": 120,
+            "keywords": [],
+            "name": "Menu eyebrow Header",
+            "parameters": {
+              "disableDynamicTitle": {
+                "description": "",
+                "name": "disableDynamicTitle",
+                "value": "true"
+              }
+            },
+            "ratingsCount": 0,
+            "state": "PUBLISHED",
+            "title": "Menu Header",
+            "typeId": 7
+          },
+          {
+            "averageRating": 0,
+            "description": "Formulaire de r\u00e9initialisation de passwords de comptes locaux du portail.",
+            "favorite": false,
+            "fname": "forgot-password",
+            "id": 8,
+            "keywords": [],
+            "name": "Mot de passe oubli\u00e9",
+            "parameters": {},
+            "ratingsCount": 0,
+            "state": "PUBLISHED",
+            "title": "Mot de passe oubli\u00e9",
+            "typeId": 7
+          },
+          {
+            "averageRating": 0,
+            "description": "Partners links for esco-portail",
+            "favorite": false,
+            "fname": "partners-footer",
+            "id": 124,
+            "keywords": [],
+            "name": "Partners Footer",
+            "parameters": {
+              "configurable": {
+                "description": "",
+                "name": "configurable",
+                "value": "true"
+              },
+              "disableDynamicTitle": {
+                "description": "",
+                "name": "disableDynamicTitle",
+                "value": "true"
+              }
+            },
+            "ratingsCount": 0,
+            "state": "PUBLISHED",
+            "title": "Partners Footer",
+            "typeId": 7
+          },
+          {
+            "averageRating": 0,
+            "description": "Gallery approach to personalization, as seen in uPortal 3.x and 4.0",
+            "favorite": false,
+            "fname": "personalization-gallery",
+            "id": 20,
+            "keywords": [],
+            "name": "Personalization Gallery",
+            "parameters": {
+              "disableDynamicTitle": {
+                "description": "",
+                "name": "disableDynamicTitle",
+                "value": "true"
+              }
+            },
+            "ratingsCount": 0,
+            "state": "PUBLISHED",
+            "title": "Personalization Gallery",
+            "typeId": 7
+          },
+          {
+            "averageRating": 0,
+            "description": "Visualisation de vos onglets et canaux",
+            "favorite": false,
+            "fname": "sitemap",
+            "id": 25,
+            "keywords": [],
+            "name": "Plan du site",
+            "parameters": {},
+            "ratingsCount": 0,
+            "state": "PUBLISHED",
+            "title": "Plan du site",
+            "typeId": 7
+          },
+          {
+            "averageRating": 0,
+            "description": "Greeting that appears at the top of the page for authenticated users",
+            "favorite": false,
+            "fname": "portal-greeting",
+            "id": 24,
+            "keywords": [],
+            "name": "Portal Greeting",
+            "parameters": {
+              "disableDynamicTitle": {
+                "description": "",
+                "name": "disableDynamicTitle",
+                "value": "true"
+              }
+            },
+            "ratingsCount": 0,
+            "state": "PUBLISHED",
+            "title": "Portal Greeting",
+            "typeId": 7
+          },
+          {
+            "averageRating": 0,
+            "description": "Afficher le titre de la portlet courante",
+            "favorite": false,
+            "fname": "focused-portlet-header",
+            "id": 123,
+            "keywords": [],
+            "name": "Portlet Courante Header",
+            "parameters": {
+              "disableDynamicTitle": {
+                "description": "",
+                "name": "disableDynamicTitle",
+                "value": "true"
+              }
+            },
+            "ratingsCount": 0,
+            "state": "PUBLISHED",
+            "title": "Portlet Courante Header",
+            "typeId": 7
+          },
+          {
+            "averageRating": 0,
+            "description": "Logo de projet collectivit\u00e9 avec lien sur l'accueil",
+            "favorite": false,
+            "fname": "project-header-logo",
+            "id": 126,
+            "keywords": [],
+            "name": "Project Logo Header",
+            "parameters": {
+              "disableDynamicTitle": {
+                "description": "",
+                "name": "disableDynamicTitle",
+                "value": "true"
+              }
+            },
+            "ratingsCount": 0,
+            "state": "PUBLISHED",
+            "title": "Project Logo Header",
+            "typeId": 7
+          },
+          {
+            "averageRating": 0,
+            "description": "Search Launcher to launch the search portlet that searches the portal, directory, and campus web.",
+            "favorite": false,
+            "fname": "search-launcher",
+            "id": 30,
+            "keywords": [],
+            "name": "SearchLauncher",
+            "parameters": {
+              "disableDynamicTitle": {
+                "description": "",
+                "name": "disableDynamicTitle",
+                "value": "true"
+              },
+              "iconUrl": {
+                "description": "",
+                "name": "iconUrl",
+                "value": "https://ent.recia.fr/ResourceServingWebapp/rs/tango/0.8.90/32x32/actions/system-search.png"
+              },
+              "mobileIconUrl": {
+                "description": "",
+                "name": "mobileIconUrl",
+                "value": "/portail/media/skins/icons/mobile/search.png"
+              },
+              "role": {
+                "description": "",
+                "name": "role",
+                "value": "searchLauncher"
+              }
+            },
+            "ratingsCount": 0,
+            "state": "PUBLISHED",
+            "title": "Search Launcher",
+            "typeId": 7
+          },
+          {
+            "averageRating": 0,
+            "description": "Provides an alert that will appear before a session timeout, giving the user the opportunity to refresh their session.",
+            "favorite": false,
+            "fname": "session-timeout",
+            "id": 31,
+            "keywords": [],
+            "name": "Session Timeout",
+            "parameters": {},
+            "ratingsCount": 0,
+            "state": "PUBLISHED",
+            "title": "Session Timeout",
+            "typeId": 7
+          },
+          {
+            "averageRating": 0,
+            "description": "Afficher l'\u00e9tablissement courant",
+            "favorite": false,
+            "fname": "etablissement-name-header",
+            "id": 121,
+            "keywords": [],
+            "name": "\u00c9tablissement courant Header",
+            "parameters": {
+              "disableDynamicTitle": {
+                "description": "",
+                "name": "disableDynamicTitle",
+                "value": "true"
+              }
+            },
+            "ratingsCount": 0,
+            "state": "PUBLISHED",
+            "title": "\u00c9tablissement courant Header",
+            "typeId": 7
+          }
+        ],
+        "subcategories": []
+      }
+    ]
+  }
+}

--- a/@uportal/esco-content-menu/public/userinfo.json
+++ b/@uportal/esco-content-menu/public/userinfo.json
@@ -1,1 +1,16 @@
-../../../docs/en/components/esco-content-menu/userinfo.json
+{
+  "ESCOSIREN": ["18450311800020", "77551105800056"],
+  "ESCOSIRENCourant": ["18450311800020"],
+  "aud": "https://my.edu/uPortal",
+  "email": "john.do@my.edu",
+  "exp": 1530779747,
+  "family_name": "Doe",
+  "gender": "M",
+  "given_name": "John",
+  "groups": ["Portal Administrators"],
+  "iat": 1530779447,
+  "iss": "https://my.edu/uPortal",
+  "name": "John Doe",
+  "phone_number": "+33 2 00 11 22 33",
+  "sub": "test"
+}

--- a/@uportal/eyebrow-user-info/README.md
+++ b/@uportal/eyebrow-user-info/README.md
@@ -1,1 +1,184 @@
-../../docs/en/components/eyebrow-user-info/README.md
+# Eyebrow User Info
+
+[![NPM Version](https://img.shields.io/npm/v/@uportal/eyebrow-user-info.svg)](https://www.npmjs.com/package/@uportal/eyebrow-user-info)
+[![Maven Central](https://maven-badges.herokuapp.com/maven-central/org.webjars.npm/uportal__eyebrow-user-info/badge.svg)](https://maven-badges.herokuapp.com/maven-central/org.webjars.npm/uportal__eyebrow-user-info)
+[![Build Status](https://travis-ci.org/uPortal-contrib/uPortal-web-components.svg?branch=master)](https://travis-ci.org/uPortal-contrib/uPortal-web-components)
+
+![Example of rendering](/eyebrow-user-info/doc/example.gif?raw=true)
+
+## Demo
+
+Within the esco-content-menu demo page:
+<https://uportal-contrib.github.io/uPortal-web-components/en/components/esco-content-menu/demo>
+
+## Usage into html
+
+```html
+<eyebrow-user-info
+  display-name="John Doe"
+  picture="https://edu.univ.org/images/noPictureUser.svg"
+  email="john.doe@edu.univ.org"
+  logout-link="/uPortal/Logout"
+  avatar-size="48px"
+  menu-is-dark="true"
+></eyebrow-user-info>
+```
+
+- displayName: required
+- email: optional
+- picture: required, the url of the user picture/avatar
+- moreLink: optional, the url to go on user information management application or any other link you want when clicking on user picture
+- logoutLink: optional, the url to sign out if you prefer to show it in the dropdown
+- menuIsDark: default value is true, set the text color into the menu to white, if false will be black, usefull for colored background
+- avatarSize: default value is "28px", set the width and heigth size of the image.
+
+## Example of use into uPortal
+
+### 1. Deploy into uPortal the builded script
+
+You should use webjar, but to test you can run `npm run build` and move `dist/eyebrow-user-info.js` into `$TOMCAT_WEBAPPS/uPortal/scripts/`
+
+### 2. Creating a jsp invoker
+
+file should be deployed into uportal jsp invoker directory `src/main/webapp/WEB-INF/jsp/Invoker/eyebrow-user-info.jsp`
+
+You should use the cdn link, or use a deployed version localy for test only !
+
+```jsp
+ <%@ include file="/WEB-INF/jsp/include.jsp" %>
+
+ <c:set var="request" value="${pageContext.request}" />
+ <c:set var="ctxPath" value="${request.contextPath}" />
+
+ <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
+ <script src="https://unpkg.com/vue@2.5.16/dist/vue.min.js"></script>
+ <script src="https://cdnjs.cloudflare.com/ajax/libs/webcomponentsjs/2.0.2/webcomponents-loader.js"></script>
+ <script type="text/javascript" language="javascript">
+   var versionUpdate = (new Date()).getTime();
+   var script = document.createElement("script");
+   script.type = "module";
+   script.src = "https://npm-cdn.herokuapp.com/@gip-recia/eyebrow-user-info@0.4.0/dist/eyebrow-user-info.js?v=" + versionUpdate;
+   document.body.appendChild(script);
+ </script>
+
+ <c:set var="avatar">
+     <c:choose>
+         <c:when test="${not empty personManager.getPerson(request).getAttribute(userPictureAttributeName[0])}">
+             ${personManager.getPerson(request).getAttribute(userPictureAttributeName[0])}
+         </c:when>
+         <c:otherwise>${alternativePicture[0]}</c:otherwise>
+     </c:choose>
+ </c:set>
+
+ <div class="eyebrow-user-info">
+     <eyebrow-user-info display-name="${userInfo['displayName']}"
+                 picture="${avatar}"
+                 email="${personManager.getPerson(request).getAttribute(userMailAttributeName[0])}"
+                 more-link="${moreUserInfoUrl[0]}"
+                 logout-link="${portalLogoutUrl[0]}"
+                 avatar-size="${avatarSize[0]}"
+                 menu-is-dark="true"></eyebrow-user-info>
+ </div>
+```
+
+### 3. Importing the portlet definition
+
+create the file `eyebrow-user-info.portlet-definition.xml` and import it
+
+```xml
+ <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+ <portlet-definition version="4.0" xsi:schemaLocation="https://source.jasig.org/schemas/uportal/io/portlet-definition https://source.jasig.org/schemas/uportal/io/portlet-definition/portlet-definition-4.0.xsd" xmlns:ns2="https://source.jasig.org/schemas/uportal" xmlns="https://source.jasig.org/schemas/uportal/io/portlet-definition" xmlns:ns4="https://source.jasig.org/schemas/uportal/io/portlet-type" xmlns:ns3="https://source.jasig.org/schemas/uportal/io/subscribed-fragment" xmlns:ns5="https://source.jasig.org/schemas/uportal/io/event-aggregation" xmlns:ns6="https://source.jasig.org/schemas/uportal/io/user" xmlns:ns7="https://source.jasig.org/schemas/uportal/io/stylesheet-descriptor" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ns8="https://source.jasig.org/schemas/uportal/io/permission-owner">
+     <title>User information Header</title>
+     <name>User information Header</name>
+     <fname>eyebrow-user-info</fname>
+     <desc>Show user informations into eyebrow header</desc>
+     <type>Portlet</type>
+     <timeout>12000</timeout>
+     <portlet-descriptor>
+         <ns2:isFramework>true</ns2:isFramework>
+         <ns2:portletName>JspInvoker</ns2:portletName>
+     </portlet-descriptor>
+     <group>Authenticated Users</group>
+     <parameter>
+         <name>disableDynamicTitle</name>
+         <value>true</value>
+     </parameter>
+     <portlet-preference>
+         <name>JspInvokerPortletController.viewLocation</name>
+         <readOnly>false</readOnly>
+         <value>/jsp/Invoker/eyebrow-user-info</value>
+     </portlet-preference>
+     <portlet-preference>
+         <name>JspInvokerPortletController.beans</name>
+         <readOnly>false</readOnly>
+         <value>personManager</value>
+     </portlet-preference>
+     <portlet-preference>
+         <name>portalLogoutUrl</name>
+         <readOnly>false</readOnly>
+         <value>/uPortal/Logout</value>
+     </portlet-preference>
+     <portlet-preference>
+         <name>moreUserInfoUrl</name>
+         <readOnly>true</readOnly>
+         <value>/uPortal/p/ESCO-MCE</value>
+     </portlet-preference>
+     <portlet-preference>
+         <name>avatarSize</name>
+         <readOnly>true</readOnly>
+         <value>28px</value>
+     </portlet-preference>
+     <portlet-preference>
+         <name>userMailAttributeName</name>
+         <readOnly>true</readOnly>
+         <value>mail</value>
+     </portlet-preference>
+     <portlet-preference>
+         <name>userPictureAttributeName</name>
+         <readOnly>true</readOnly>
+         <value>ESCOPersonPhoto</value>
+     </portlet-preference>
+     <portlet-preference>
+         <name>alternativePicture</name>
+         <readOnly>true</readOnly>
+         <value>/images/icones/noPictureUser.svg</value>
+     </portlet-preference>
+ </portlet-definition>
+```
+
+### 4. Adding it to the layout
+
+modify the file `authenticated-lo.fragment-layout.xml`
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<layout xmlns:dlm="http://www.uportal.org/layout/dlm" script="classpath://org/jasig/portal/io/import-layout_v3-2.crn"
+        username="authenticated-lo" >
+    <folder ID="s1" hidden="false" immutable="false" name="Root folder" type="root" unremovable="true">
+        <!--
+         | Hidden folders do not propagate to regular users, and fragment owner
+         | accounts don't receive (other) fragments at all;  Fragment owners must
+         | have their own copies of the minimal portlets required to view and manage
+         | their own layouts.
+         +-->
+        <folder ID="s20" hidden="true" immutable="true" name="Page Top folder" type="page-top" unremovable="true">
+            <channel fname="dynamic-respondr-skin" unremovable="false" hidden="false" immutable="false" ID="n22"/>
+            <channel fname="fragment-admin-exit" unremovable="false" hidden="false" immutable="false" ID="n24"/>
+        </folder>
+        <!-- Customize is already included on the page, so don't include it a 2nd time for layout admin.  It would
+             mess it up.
+        <folder ID="s40" hidden="true" immutable="true" name="Customize folder" type="customize" unremovable="true">
+            <channel fname="personalization-gallery" unremovable="false" hidden="false" immutable="false" ID="n42"/>
+        </folder> -->
+        <folder ID="s100" hidden="false" immutable="true" name="Eyebrow folder" type="eyebrow" unremovable="true">
+            <channel fname="notification-icon" unremovable="false" hidden="false" immutable="false" ID="n110"/>
+            <channel fname="eyebrow-user-info" unremovable="false" hidden="false" immutable="false" ID="n120"/>
+            <channel fname="session-timeout" unremovable="false" hidden="false" immutable="false" ID="n140"/>
+        </folder>
+        <folder ID="s300" hidden="false" immutable="true" name="Customize folder" type="customize" unremovable="true">
+            <channel fname="personalization-gallery" unremovable="false" hidden="false" immutable="false" ID="n310"/>
+            <channel fname="background-preference" unremovable="true" hidden="false" immutable="false" ID="n320"/>
+        </folder>
+    </folder>
+</layout>
+```


### PR DESCRIPTION
finally replace symlink by copy of file between project path and doc path. It's usefull for npm site as the webcomponent project documentation doesn't appear on.

A script could help to avoid such manipulation based on these examples/docs: [using pre-commit script](https://github.com/observing/pre-commit) with a [git hook script](https://medium.com/@shalvah/hacking-it-out-ensuring-code-quality-with-hooks-and-scripts-c5113f0b0ec7)