### PR TITLE
feat: add hover text to cards based on portlet title or desc

### DIFF
--- a/@uportal/esco-content-menu/README.md
+++ b/@uportal/esco-content-menu/README.md
@@ -302,6 +302,7 @@ Standalone properties:
 - `hide-title`: `Boolean`, default: `false`, define to remove the title area from the grid, useful when a basic grid is desired
 - `portlet-background-is-dark`: `Boolean`, default: `false`, indicate to the component that the parent background is dark and permit to the portlet-card component to show buttons like favorites in a more suitable color.
 - `debug`: type: `Boolean`, default: `false`, for the demo/debug mode to be able to run in a standalone way (disable api call)
+- `card-hover-src`: type: possible value `none|title|desc|description`, default: `none`, set the hover text for the grid cards to one of the portlet definition values `title` or `description`
 
 and additional properties to work with the parent component `content-menu`:
 

--- a/@uportal/esco-content-menu/src/App.vue
+++ b/@uportal/esco-content-menu/src/App.vue
@@ -28,6 +28,7 @@
       layout-api-url="layout.json"
       organization-api-url="orginfo.json"
       user-info-api-url="userinfo.json"
+      card-hover-src="title"
       :show-favorites-in-slider="false"
       debug
     >

--- a/@uportal/esco-content-menu/src/components/ContentGrid.vue
+++ b/@uportal/esco-content-menu/src/components/ContentGrid.vue
@@ -72,6 +72,7 @@
               :user-info-api-url="userInfoApiUrl"
               :back-ground-is-dark="portletBackgroundIsDark"
               :debug="debug"
+              :card-hover-src="cardHoverSrc"
             />
           </a>
         </div>
@@ -177,6 +178,7 @@ export default {
     showFooterCategories: { type: Boolean, default: false },
     useExternalFilter: { type: Boolean, default: true },
     portletBackgroundIsDark: { type: Boolean, default: false },
+    cardHoverSrc: { type: String, default: 'none' },
   },
   data() {
     return {

--- a/@uportal/esco-content-menu/src/components/ContentMenu.vue
+++ b/@uportal/esco-content-menu/src/components/ContentMenu.vue
@@ -62,6 +62,7 @@
       :context-api-url="contextApiUrl"
       :portlet-api-url="portletApiUrl"
       :debug="debug"
+      :card-hover-src="cardHoverSrc"
     />
     <vue-simple-spinner
       v-show="isLoading"
@@ -165,6 +166,7 @@ export default {
       default: 'otherAttributes.ESCOStructureLogo[0]',
     },
     showFavoritesInSlider: { type: Boolean, default: true },
+    cardHoverSrc: { type: String, default: 'none' },
   },
   data() {
     return {

--- a/@uportal/esco-content-menu/src/components/PortletCard.vue
+++ b/@uportal/esco-content-menu/src/components/PortletCard.vue
@@ -1,5 +1,5 @@
 <template>
-  <div :class="mainClass">
+  <div :class="mainClass" v-bind:title="hover">
     <div class="portlet-card-icon">
       <div
         v-if="iconUrl !== null"
@@ -81,6 +81,7 @@ export default {
     hideAction: { type: Boolean, default: false },
     portletDesc: { type: Object, required: true },
     backGroundIsDark: { type: Boolean, default: false },
+    cardHoverSrc: { type: String, default: 'none' },
   },
   data() {
     return {
@@ -88,6 +89,11 @@ export default {
       channelId: this.portletDesc.id,
       description: this.portletDesc.description,
       title: this.portletDesc.title,
+      hover: this.hoverText(
+        this.cardHoverSrc,
+        this.portletDesc.title,
+        this.portletDesc.description
+      ),
       canFavorite: this.portletDesc?.canAdd ? this.portletDesc.canAdd : true,
       iconUrl: computeUrl(
         this.portletDesc.parameters?.iconUrl?.value
@@ -135,6 +141,17 @@ export default {
         return text[0].trim();
       }
       return entry;
+    },
+    hoverText(cardHoverSrc, title, description) {
+      switch (cardHoverSrc) {
+        case 'title':
+          return title;
+        case 'desc':
+        case 'description':
+          return description;
+        default:
+          return null;
+      }
     },
   },
 };


### PR DESCRIPTION
Configure optional `title` text for grid portlet-cards for display when hovering. Source can be `none`, portlet `title`, or portlet `description`.

README updated