### PR TITLE
fix: added missing title attribute to grid carousel links

### DIFF
--- a/@uportal/grid-carousel/src/grid-carousel.js
+++ b/@uportal/grid-carousel/src/grid-carousel.js
@@ -187,6 +187,7 @@ class GridCarousel extends LitElement {
                       <a
                         href="${item.link}"
                         background="${item.image}"
+                        title="${item.label}"
                         target="${item.targetLink}"
                         rel="${item.targetLink === '_blank'
                           ? 'noopener noreferrer'
@@ -211,6 +212,7 @@ class GridCarousel extends LitElement {
                       href="${item.link}"
                       background="${item.image}"
                       target="${item.targetLink}"
+                      title="${item.label}"
                       rel="${item.targetLink === '_blank'
                         ? 'noopener noreferrer'
                         : ''}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased][]
 
+- fix(grid-carousel): Added missing title attribute to links
+
 ## [1.40.1][]
 
 - fix(publish): Fixed issue with package.json and publishing for grid-carousel


### PR DESCRIPTION
This fix adds a missing title attribute to the links in the grid-carousel component